### PR TITLE
Support automatic writing of Google creds to AWS

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -60,5 +60,5 @@ jobs:
           auth: "google"
           googleClientId: ${{ secrets.GOOGLE_CLIENT_ID }}
           googleClientSecret: ${{ secrets.GOOGLE_CLIENT_SECRET }}
-          GU_ACTIONS_STATIC_SITE_ROLE_ARN: ${{ secrets.GU_ACTIONS_STATIC_SITE_ROLE_ARN }}
-          GU_RIFF_RAFF_ROLE_ARN: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          guActionsStaticSiteRoleArn: ${{ secrets.GU_ACTIONS_STATIC_SITE_ROLE_ARN }}
+          guActionsRiffRaffRoleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -60,3 +60,5 @@ jobs:
           auth: "google"
           googleClientId: ${{ secrets.GOOGLE_CLIENT_ID }}
           googleClientSecret: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+          GU_ACTIONS_STATIC_SITE_ROLE_ARN: ${{ secrets.GU_ACTIONS_STATIC_SITE_ROLE_ARN }}
+          GU_RIFF_RAFF_ROLE_ARN: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -58,5 +58,5 @@ jobs:
           app: the-coolest-static-site
           domain: test.devx.gutools.co.uk
           auth: "google"
-          googleClientId: ${secret.GOOGLE_CLIENT_ID}
-          googleClientSecret: ${secret.GOOGLE_CLIENT_SECRET}
+          googleClientId: ${{ secrets.GOOGLE_CLIENT_ID }}
+          googleClientSecret: ${{ secrets.GOOGLE_CLIENT_SECRET }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -58,3 +58,5 @@ jobs:
           app: the-coolest-static-site
           domain: test.devx.gutools.co.uk
           auth: "google"
+          googleClientId: ${secret.GOOGLE_CLIENT_ID}
+          googleClientSecret: ${secret.GOOGLE_CLIENT_SECRET}

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Example usage:
     app: 'example-app'
     domain: 'example-app.gutools.co.uk'
     auth: 'google'
-    googleClientId: ${secret.GOOGLE_CLIENT_ID}
-    googleClientSecret: ${secret.GOOGLE_CLIENT_SECRET}
+    googleClientId: ${{ secrets.GOOGLE_CLIENT_ID }}
+    googleClientSecret: ${{ secrets.GOOGLE_CLIENT_SECRET }}
 ```
 
 If using Google auth (recommended) request credentials from DevX (`P&E/DevX

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Example usage:
     auth: 'google'
     googleClientId: ${{ secrets.GOOGLE_CLIENT_ID }}
     googleClientSecret: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+    guActionsStaticSiteRoleArn: ${{ secrets.GU_ACTIONS_STATIC_SITE_ROLE_ARN }}
+    guActionsRiffRaffRoleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+
 ```
 
 If using Google auth (recommended) request credentials from DevX (`P&E/DevX

--- a/action.yaml
+++ b/action.yaml
@@ -20,10 +20,10 @@ inputs:
   googleClientSecret:
     description: "DO NOT INLINE - pass as a secret."
     required: false
-  GU_ACTIONS_STATIC_SITE_ROLE_ARN:
+  guActionsStaticSiteRoleArn:
     description: "Role to use for writing to SSM Parameter store (typically org secret of same name)."
     required: true
-  GU_RIFF_RAFF_ROLE_ARN:
+  guActionsRiffRaffRoleArn:
     description: "Role to use for writing to Riffraff's AWS bucket (typically org secret of same name)."
     required: true
   dryRun:
@@ -37,7 +37,7 @@ runs:
     - uses: aws-actions/configure-aws-credentials@v1
       with:
         aws-region: eu-west-1
-        role-to-assume: ${{ inputs.GU_ACTIONS_STATIC_SITE_ROLE_ARN }}
+        role-to-assume: ${{ inputs.guActionsStaticSiteRoleArn }}
 
     - name: CDK synth
       shell: bash
@@ -72,7 +72,7 @@ runs:
     - uses: aws-actions/configure-aws-credentials@v1
       with:
         aws-region: eu-west-1
-        role-to-assume: ${{ inputs.GU_RIFF_RAFF_ROLE_ARN }}
+        role-to-assume: ${{ inputs.guActionsRiffRaffRoleArn }}
 
     - uses: guardian/actions-riff-raff@v1
       with:

--- a/action.yaml
+++ b/action.yaml
@@ -14,6 +14,12 @@ inputs:
     description: "Name of artifact containing the static site. Should be uploaded in an earlier workflow step."
     required: false
     default: "artifact"
+  GU_ACTIONS_STATIC_SITE_ROLE_ARN:
+    description: "Role to use for writing to SSM Parameter store (typically org secret of same name)."
+    required: true
+  GU_RIFF_RAFF_ROLE_ARN:
+    description: "Role to use for writing to Riffraff's AWS bucket (typically org secret of same name)."
+    required: true
   dryRun:
     description: "If set to true, will not upload Riffraff artifact."
     default: false
@@ -25,7 +31,7 @@ runs:
     - uses: aws-actions/configure-aws-credentials@v1
       with:
         aws-region: eu-west-1
-        role-to-assume: ${{ secrets.GU_ACTIONS_STATIC_SITE_ROLE_ARN }}
+        role-to-assume: ${{ inputs.GU_ACTIONS_STATIC_SITE_ROLE_ARN }}
 
     - name: CDK synth
       shell: bash
@@ -59,7 +65,7 @@ runs:
     - uses: aws-actions/configure-aws-credentials@v1
       with:
         aws-region: eu-west-1
-        role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+        role-to-assume: ${{ inputs.GU_RIFF_RAFF_ROLE_ARN }}
 
     - uses: guardian/actions-riff-raff@v1
       with:

--- a/action.yaml
+++ b/action.yaml
@@ -25,7 +25,7 @@ runs:
     - uses: aws-actions/configure-aws-credentials@v1
       with:
         aws-region: eu-west-1
-        role-to-assume: ${{ secret.GU_ACTIONS_STATIC_SITE_ROLE_ARN }}
+        role-to-assume: ${{ secrets.GU_ACTIONS_STATIC_SITE_ROLE_ARN }}
 
     - name: CDK synth
       shell: bash
@@ -59,7 +59,7 @@ runs:
     - uses: aws-actions/configure-aws-credentials@v1
       with:
         aws-region: eu-west-1
-        role-to-assume: ${{ secret.GU_RIFF_RAFF_ROLE_ARN }}
+        role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
 
     - uses: guardian/actions-riff-raff@v1
       with:

--- a/action.yaml
+++ b/action.yaml
@@ -44,7 +44,6 @@ runs:
       run: |
         cd ${{github.action_path}}
         ls -hal
-        tree .
         node index.js
       env:
         INPUT_APP: ${{ inputs.app }}
@@ -53,6 +52,8 @@ runs:
         INPUT_ARTIFACT: ${{ inputs.artifact }}
         INPUT_DRYRUN: ${{ inputs.dryRun}}
         INPUT_ACTIONS_RUNTIME_TOKEN: ${ github.token }
+        INPUT_GOOGLECLIENTID: ${{ inputs.googleClientId }}
+        INPUT_GOOGLECLIENTSECRET: ${{ inputs.googleClientSecret }}
 
     - uses: actions/download-artifact@v3
       with:

--- a/action.yaml
+++ b/action.yaml
@@ -14,6 +14,12 @@ inputs:
     description: "Name of artifact containing the static site. Should be uploaded in an earlier workflow step."
     required: false
     default: "artifact"
+  googleClientId:
+    description: "Google (oauth) client ID"
+    required: false
+  googleClientSecret:
+    description: "DO NOT INLINE - pass as a secret."
+    required: false
   GU_ACTIONS_STATIC_SITE_ROLE_ARN:
     description: "Role to use for writing to SSM Parameter store (typically org secret of same name)."
     required: true

--- a/action.yaml
+++ b/action.yaml
@@ -9,8 +9,7 @@ inputs:
     required: true
   auth:
     description: Auth mechanism to use.
-    required: false
-    default: "google"
+    required: true
   artifact:
     description: "Name of artifact containing the static site. Should be uploaded in an earlier workflow step."
     required: false
@@ -23,6 +22,11 @@ runs:
   # env) so need to be passed them explicitly :(. Sad times I know.
   using: "composite"
   steps:
+    - uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-region: eu-west-1
+        role-to-assume: ${{ secret.GU_ACTIONS_STATIC_SITE_ROLE_ARN }}
+
     - name: CDK synth
       shell: bash
       run: |
@@ -52,7 +56,10 @@ runs:
       shell: bash
       run: zip -r site.zip site
 
-    # TODO credentials stuff!
+    - uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-region: eu-west-1
+        role-to-assume: ${{ secret.GU_RIFF_RAFF_ROLE_ARN }}
 
     - uses: guardian/actions-riff-raff@v1
       with:

--- a/index.ts
+++ b/index.ts
@@ -41,6 +41,7 @@ export const main = async (): Promise<void> => {
       Name: `/actions-static-site/${app}/googleClientId`,
       Value: googleClientId,
       Type: "String",
+      Overwrite: true,
     });
     await client.send(setClientId);
 
@@ -48,6 +49,7 @@ export const main = async (): Promise<void> => {
       Name: `/actions-static-site/${app}/googleClientSecret`,
       Value: googleClientSecret,
       Type: "SecureString",
+      Overwrite: true,
     });
 
     await client.send(setSecret);

--- a/index.ts
+++ b/index.ts
@@ -2,14 +2,46 @@ import * as core from "@actions/core";
 import { Template } from "aws-cdk-lib/assertions";
 import { App } from "aws-cdk-lib";
 import { StaticSite } from "./cdk/static-site";
+import { PutParameterCommand, SSMClient } from "@aws-sdk/client-ssm";
 import * as fs from "fs";
 
 export const main = async (): Promise<void> => {
   const app = core.getInput("app", { required: true });
   const domain = core.getInput("domain", { required: true });
-  const auth = core.getInput("auth");
-  const stack = "deploy"; // TODO support all stacks
-  core.info(JSON.stringify({ app, stack, domain, auth }));
+  const auth = core.getInput("auth", { required: true });
+  const googleClientId = core.getInput("googleClientId");
+  const googleClientSecret = core.getInput("googleClientSecret");
+  const stack = "deploy";
+
+  core.info("Inputs are: " + JSON.stringify({ app, stack, domain, auth }));
+
+  if (auth === "google") {
+    if (googleClientId === "" || googleClientSecret === "") {
+      core.setFailed(
+        "The following inputs are required to be non-empty when auth='google': ['googleClientId', 'googleClientSecret']."
+      );
+
+      return;
+    }
+
+    // upload to Parameter Store
+    const client = new SSMClient({ region: "eu-west-1" });
+
+    const setClientId = new PutParameterCommand({
+      Name: `/actions-static-site/${app}/googleClientId`,
+      Value: googleClientId,
+      Type: "String",
+    });
+    await client.send(setClientId);
+
+    const setSecret = new PutParameterCommand({
+      Name: `/actions-static-site/${app}/googleClientSecret`,
+      Value: googleClientSecret,
+      Type: "SecureString",
+    });
+
+    await client.send(setSecret);
+  }
 
   const cdkApp = new App();
   const cdkStack = new StaticSite(cdkApp, "static-site", {

--- a/index.ts
+++ b/index.ts
@@ -13,7 +13,17 @@ export const main = async (): Promise<void> => {
   const googleClientSecret = core.getInput("googleClientSecret");
   const stack = "deploy";
 
-  core.info("Inputs are: " + JSON.stringify({ app, stack, domain, auth }));
+  core.info(
+    "Inputs are: " +
+      JSON.stringify({
+        app,
+        stack,
+        domain,
+        auth,
+        googleClientId,
+        googleClientSecret: googleClientSecret !== "" ? "******" : "",
+      })
+  );
 
   if (auth === "google") {
     if (googleClientId === "" || googleClientSecret === "") {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@actions/artifact": "^1.1.0",
         "@actions/core": "^1.6.0",
+        "@aws-sdk/client-ssm": "^3.181.0",
         "esbuild": "^0.14.29",
         "js-yaml": "^4.1.0"
       },
@@ -72,6 +73,890 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/ie11-detection": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
+      "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
+      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^2.0.0",
+        "@aws-crypto/sha256-js": "^2.0.0",
+        "@aws-crypto/supports-web-crypto": "^2.0.0",
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
+      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+      "dependencies": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
+      "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
+      "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.110.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/abort-controller": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.178.0.tgz",
+      "integrity": "sha512-ptDkCB06BJrYdhKzamM9yI15LxcGkPczY80hzKAY/aecm09alnW27uCt5HJJx2nCd18IUH28ZO1sc7DTLOWb3A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm": {
+      "version": "3.181.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.181.0.tgz",
+      "integrity": "sha512-slaAaZccbJeyMqONp+Q04+fE2KCeMXYv38Syc/cFD8eL1jZsCdGa4MqBJ1z95YnHsvMsc18UBgUIOeGiIlpxCg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.181.0",
+        "@aws-sdk/config-resolver": "3.178.0",
+        "@aws-sdk/credential-provider-node": "3.181.0",
+        "@aws-sdk/fetch-http-handler": "3.178.0",
+        "@aws-sdk/hash-node": "3.178.0",
+        "@aws-sdk/invalid-dependency": "3.178.0",
+        "@aws-sdk/middleware-content-length": "3.178.0",
+        "@aws-sdk/middleware-host-header": "3.178.0",
+        "@aws-sdk/middleware-logger": "3.178.0",
+        "@aws-sdk/middleware-recursion-detection": "3.178.0",
+        "@aws-sdk/middleware-retry": "3.178.0",
+        "@aws-sdk/middleware-serde": "3.178.0",
+        "@aws-sdk/middleware-signing": "3.179.0",
+        "@aws-sdk/middleware-stack": "3.178.0",
+        "@aws-sdk/middleware-user-agent": "3.178.0",
+        "@aws-sdk/node-config-provider": "3.178.0",
+        "@aws-sdk/node-http-handler": "3.178.0",
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/smithy-client": "3.180.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/url-parser": "3.178.0",
+        "@aws-sdk/util-base64-browser": "3.170.0",
+        "@aws-sdk/util-base64-node": "3.170.0",
+        "@aws-sdk/util-body-length-browser": "3.170.0",
+        "@aws-sdk/util-body-length-node": "3.170.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.180.0",
+        "@aws-sdk/util-defaults-mode-node": "3.180.0",
+        "@aws-sdk/util-user-agent-browser": "3.178.0",
+        "@aws-sdk/util-user-agent-node": "3.178.0",
+        "@aws-sdk/util-utf8-browser": "3.170.0",
+        "@aws-sdk/util-utf8-node": "3.170.0",
+        "@aws-sdk/util-waiter": "3.180.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.181.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.181.0.tgz",
+      "integrity": "sha512-p/HsYVAO7fgjFfn4LqlnlpSKPXGPegAwjPpY+SqyK3/Hj1OtED4whG8LTgxZSTtYwNIkHEjrHnXTiymyXh34Aw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.178.0",
+        "@aws-sdk/fetch-http-handler": "3.178.0",
+        "@aws-sdk/hash-node": "3.178.0",
+        "@aws-sdk/invalid-dependency": "3.178.0",
+        "@aws-sdk/middleware-content-length": "3.178.0",
+        "@aws-sdk/middleware-host-header": "3.178.0",
+        "@aws-sdk/middleware-logger": "3.178.0",
+        "@aws-sdk/middleware-recursion-detection": "3.178.0",
+        "@aws-sdk/middleware-retry": "3.178.0",
+        "@aws-sdk/middleware-serde": "3.178.0",
+        "@aws-sdk/middleware-stack": "3.178.0",
+        "@aws-sdk/middleware-user-agent": "3.178.0",
+        "@aws-sdk/node-config-provider": "3.178.0",
+        "@aws-sdk/node-http-handler": "3.178.0",
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/smithy-client": "3.180.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/url-parser": "3.178.0",
+        "@aws-sdk/util-base64-browser": "3.170.0",
+        "@aws-sdk/util-base64-node": "3.170.0",
+        "@aws-sdk/util-body-length-browser": "3.170.0",
+        "@aws-sdk/util-body-length-node": "3.170.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.180.0",
+        "@aws-sdk/util-defaults-mode-node": "3.180.0",
+        "@aws-sdk/util-user-agent-browser": "3.178.0",
+        "@aws-sdk/util-user-agent-node": "3.178.0",
+        "@aws-sdk/util-utf8-browser": "3.170.0",
+        "@aws-sdk/util-utf8-node": "3.170.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.181.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.181.0.tgz",
+      "integrity": "sha512-j//F9kjdSv9lUa8p87cg+xk6l5E8o8+GTYP5838eFQR7XcEc3yEljSCkuj2xIzrtf1jKuMXBnswTKmxJhjbTzQ==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.178.0",
+        "@aws-sdk/credential-provider-node": "3.181.0",
+        "@aws-sdk/fetch-http-handler": "3.178.0",
+        "@aws-sdk/hash-node": "3.178.0",
+        "@aws-sdk/invalid-dependency": "3.178.0",
+        "@aws-sdk/middleware-content-length": "3.178.0",
+        "@aws-sdk/middleware-host-header": "3.178.0",
+        "@aws-sdk/middleware-logger": "3.178.0",
+        "@aws-sdk/middleware-recursion-detection": "3.178.0",
+        "@aws-sdk/middleware-retry": "3.178.0",
+        "@aws-sdk/middleware-sdk-sts": "3.179.0",
+        "@aws-sdk/middleware-serde": "3.178.0",
+        "@aws-sdk/middleware-signing": "3.179.0",
+        "@aws-sdk/middleware-stack": "3.178.0",
+        "@aws-sdk/middleware-user-agent": "3.178.0",
+        "@aws-sdk/node-config-provider": "3.178.0",
+        "@aws-sdk/node-http-handler": "3.178.0",
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/smithy-client": "3.180.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/url-parser": "3.178.0",
+        "@aws-sdk/util-base64-browser": "3.170.0",
+        "@aws-sdk/util-base64-node": "3.170.0",
+        "@aws-sdk/util-body-length-browser": "3.170.0",
+        "@aws-sdk/util-body-length-node": "3.170.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.180.0",
+        "@aws-sdk/util-defaults-mode-node": "3.180.0",
+        "@aws-sdk/util-user-agent-browser": "3.178.0",
+        "@aws-sdk/util-user-agent-node": "3.178.0",
+        "@aws-sdk/util-utf8-browser": "3.170.0",
+        "@aws-sdk/util-utf8-node": "3.170.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/config-resolver": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.178.0.tgz",
+      "integrity": "sha512-8xL98TGMaVULIN7HRWV2q1o0Y2p38QuweehzM8yXCZrrLOyHgWo3waP2RNVeddOB7MrSwwU/gw9rXSv7YHLZ6w==",
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-config-provider": "3.170.0",
+        "@aws-sdk/util-middleware": "3.178.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.178.0.tgz",
+      "integrity": "sha512-5CMswTJ188RuK9TmI5yAosIsyu4Mm9Cdq1068tRls5EqqwGK1PI7Q007b6rD7zqCb5IgeFBV0t2DxHkBmHRd3w==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.178.0.tgz",
+      "integrity": "sha512-ZvqQTi3+S13LACVgaWNCOKBv5jROIz7rqyZh56QunAkaAUqPbpM4VFODgAGZYPCOSggZbEUUqXOVB9xSnshLnA==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.178.0",
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/url-parser": "3.178.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.181.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.181.0.tgz",
+      "integrity": "sha512-jOa42qYFgkdMumw0IRO0ASAjM0vZMXvPpy3DGOaG0Ehy4KHeykEj4/J23SxCTCkOqAbz2+8XVCuyTExUmWCuWw==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.178.0",
+        "@aws-sdk/credential-provider-imds": "3.178.0",
+        "@aws-sdk/credential-provider-sso": "3.181.0",
+        "@aws-sdk/credential-provider-web-identity": "3.178.0",
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/shared-ini-file-loader": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.181.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.181.0.tgz",
+      "integrity": "sha512-RlLdp+7faCKzJsmUlBSr4CjqN9WG+YZpmuVVlW5fXGUdXLBLEvLMTl5rmwKtRSUytyYK0Vqtmt48I4nBze8MrA==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.178.0",
+        "@aws-sdk/credential-provider-imds": "3.178.0",
+        "@aws-sdk/credential-provider-ini": "3.181.0",
+        "@aws-sdk/credential-provider-process": "3.178.0",
+        "@aws-sdk/credential-provider-sso": "3.181.0",
+        "@aws-sdk/credential-provider-web-identity": "3.178.0",
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/shared-ini-file-loader": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.178.0.tgz",
+      "integrity": "sha512-J4TldKrAnfayvRfxNEnLJUnTgkpTcct6rc7PwZlVSGSUgjglbcqfemUOP/pisLKbVNNL742lsUXmkUVH4km0Fw==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/shared-ini-file-loader": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.181.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.181.0.tgz",
+      "integrity": "sha512-03YAvns+P7hw5rLwYLExezn9iGX9HD2GAKCEgpSaZSlNLzMw0jU7VEmqJvrLqi+xAoshuRR5A3v8HFQU246QRA==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.181.0",
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/shared-ini-file-loader": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.178.0.tgz",
+      "integrity": "sha512-aei8o9ALtzwgYsZCAWdr+ItJyYTkYRmCoKstM4mkGtWNK9BjdISaVUAnndl6Pc/l/5eiK+2rlA+6Ujs4H8m+XQ==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.178.0.tgz",
+      "integrity": "sha512-T/LCNwCihdVNzGn39Dw7tk2U1fMlupFlCsAvDBbO+FOM3h+y9WLHzxmlAVsjPrFXlzdONKf9zd5cuQ+ZW93yAQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/querystring-builder": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-base64-browser": "3.170.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/hash-node": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.178.0.tgz",
+      "integrity": "sha512-mqYraRQlvPO5egUKTNZ1kP52sfwBlsz7woOewQTHOGomZBDXrh8bl1J+sgaDi1NAwXdZUgxuD3QKxxAKRs9a2Q==",
+      "dependencies": {
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-buffer-from": "3.170.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.178.0.tgz",
+      "integrity": "sha512-JJNaiLr3nbRYym6oUAAaoFFYtDnIZ9Scco2p4sG/thT2eyAfXcEdNl1cSD3E/R1J+Ml/YplqTiIY4u1KPAriRw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.170.0.tgz",
+      "integrity": "sha512-yYXqgp8rilBckIvNRs22yAXHKcXb86/g+F+hsTZl38OJintTsLQB//O5v6EQTYhSW7T3wMe1NHDrjZ+hFjAy4Q==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.178.0.tgz",
+      "integrity": "sha512-p3n3IzU03eRzZivEoQn1HA83LbAKukZwRevsJpya1UfCUtWkXQO3v0jU8rhZE4deGa9k7zuCAEmJ8nCw3QxclQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.178.0.tgz",
+      "integrity": "sha512-EFc9S63iwCmudVpVSiVPiTnp6WCfsRYUmTrZJJouZzthEhJwcrunwu7Fa9lHYb0zcWLgVFLhzs1Z34J/Er4JoQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.178.0.tgz",
+      "integrity": "sha512-k4jnB+ryGiAhv6vyNFz2YoaVodldjkbz4mqDlVzhwEn77LT/TcwdBoown3cJD/45LEtiuPqeONoTcNCsuCkRFQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.178.0.tgz",
+      "integrity": "sha512-dVgSoP2Mer8A0JGaWgpC/f4vPyvHh7laES/u5sTy6RfwrR87oTx+uhKrc6eh+9NkMR2xdRyaNJAMIXwL5bsVzg==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.178.0.tgz",
+      "integrity": "sha512-glBXpAqt+4KQ7q8y2/kwDX2ujCvCSQok5rlAmUjaQjVPc3cX77QwATIRQTS2nBC4v9tfMc7yL64ZeRbx6n0RAQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/service-error-classification": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-middleware": "3.178.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-retry/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.179.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.179.0.tgz",
+      "integrity": "sha512-uU9UdG9ornvblXdLLNsZNpgMOA9vgFMB93zo3DL/Q6MPmYprZYyK7dUiA06i1pe4HP2gR3N3hxXwzmKU6Bjt6A==",
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.179.0",
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/signature-v4": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.178.0.tgz",
+      "integrity": "sha512-TERiu/B4hYi5Jd4iQN9ECTWbt2IZweAgFB010MboM4CAPm6EcszEc/uCB4faLZNdJaksk1BhAR7koURcda8Sew==",
+      "dependencies": {
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.179.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.179.0.tgz",
+      "integrity": "sha512-rtB6t3w1Km3ngO1yoiEUqsobujcBk36oPs2fTUKTbmuTr+54YH3NF0zAwVJv08lpfAs56holtp+bYyAxZJIxSQ==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/signature-v4": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-middleware": "3.178.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.178.0.tgz",
+      "integrity": "sha512-ELYM5Imhlcz2zT1Z4OjVZwO564KvI4L9dMBxuUgO0fwommzjWqxR03yaRGhpGwpCP64d0Op5Koc/RKq5V92Wbw==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.178.0.tgz",
+      "integrity": "sha512-xkKBxrFbs+UwUPpfIGEPuHeBWS2Jgmcd+ipEJUQRR3lY4h1fJ6mPGeyyaVDvwaJp9KgESSI6QTp6V15l8GXXgQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.178.0.tgz",
+      "integrity": "sha512-yb5XJcC7SxkZ5oxu3zQ/foBdMkLBKryzx/CVg5BNSsKDjfbouf/ZYPcJDHhc2gzCtZcx18GjFBOnv8cpo/tyXQ==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/shared-ini-file-loader": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.178.0.tgz",
+      "integrity": "sha512-EtH6YiX1IX0QraQ/+kKBWAEtsFYBnFyxOimTBtlpDYwFpgDzIZ1GFn2wORYomEWALg10kphs8n3E5/7b5t5OWQ==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.178.0",
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/querystring-builder": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/property-provider": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.178.0.tgz",
+      "integrity": "sha512-+Fh1aUANa+Gt/rh4SUHO0yHwKsibyZGk2LLDUcM1+9r0pUZT0qy3h0UCl5Kkj9HUcDJMD73wHTx4UB440xRobw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/protocol-http": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.178.0.tgz",
+      "integrity": "sha512-GsnANW60mVYMlE16UGNSOwYZ6TbkoODvmDQi95SEPjM7asf4vihEyDvhxiGS/JvC18UyxRVWT89l/V3hR/SF7w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.178.0.tgz",
+      "integrity": "sha512-vJXlExSshlHtGVvan/U6JihWvzf8t9QwH5I4F6HUY+exxMy5vFDYCnNqGAzbJwq7w/HME1gQWLoXq2k0uODz7g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-uri-escape": "3.170.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.178.0.tgz",
+      "integrity": "sha512-dp3pLnsOvAcIF7Yn2PY5CIVWX7GvC33nSlWDYeLeCMapccwTbe6zBqreWbScmIGJra4QJTdjccpwo2Yxwhr5QQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.178.0.tgz",
+      "integrity": "sha512-tDKTBXxck2N4bhAnQaeokx9ps38V3G70lcDdHS/N9hmqcQQmH5x+1/AMwYWLjUZmOQPBW9sFoG4B3psnl+sefw==",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.178.0.tgz",
+      "integrity": "sha512-nZGmuhGLDFbXsb7QYDg7PiPMAmsdlSshKJ+AhKSZF/J0SK94kdZgGnGXGUZe52S3G41E3CZIgnLnnsMXq0uErA==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.178.0.tgz",
+      "integrity": "sha512-8oOx6o0uOqlCDPM0dszfR1WHqd0E1VuFqez8iNItp0DhmhaCuanEwKYYA6HOkVu/MA6CsG6zDIJaFr5ODU2NvQ==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.170.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-hex-encoding": "3.170.0",
+        "@aws-sdk/util-middleware": "3.178.0",
+        "@aws-sdk/util-uri-escape": "3.170.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/smithy-client": {
+      "version": "3.180.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.180.0.tgz",
+      "integrity": "sha512-1vWafiUdn6RvOsD4CyNjMeDtDujuPi4Iq4Db6HrFmVPpJAutOLlCg52Dt7k96KCcIKgxVAs6Br0Waef+pcoGNA==",
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.178.0.tgz",
+      "integrity": "sha512-CrHxHzXSEr/Z3NLFvJgSGHGcD9tYUZ0Rhp8tFCSpD3TpBo3/Y7RIvqaEPvECsL52UEloeBhQf65AO8590YkVmQ==",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/url-parser": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.178.0.tgz",
+      "integrity": "sha512-+Ch29d+IZG6zD1gNDVgFC00huY8ytrPdijAuNJ4DtPBTGP4zbrImw3js0GfvfBjLrQYBnclcAvSx4J1Q/8tqBQ==",
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-base64-browser": {
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.170.0.tgz",
+      "integrity": "sha512-uLP9Kp74+jc+UWI392LSWIaUj9eXZBhkAiSm8dXAyrr+5GFOKvmEdidFoZKKcFcZ2v3RMonDgFVcDBiZ33w7BQ==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-base64-node": {
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.170.0.tgz",
+      "integrity": "sha512-sjpOmfyW0RWCLXU8Du0ZtwgFoxIuKQIyVygXJ4qxByoa3jIUJXf4U33uSRMy47V3JoogdZuKSpND9hiNk2wU4w==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.170.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.170.0.tgz",
+      "integrity": "sha512-SqSWA++gsZgHw6tlcEXx9K6R6cVKNYzOq6bca+NR7jXvy1hfqiv9Gx5TZrG4oL4JziP8QA0fTklmI1uQJ4HBRA==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.170.0.tgz",
+      "integrity": "sha512-sFb85ngsgfpamwDn22LC/+FkbDTNiddbMHptkajw+CAD2Rb4SJDp2PfXZ6k883BueJWhmxZ9+lApHZqYtgPdzw==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.170.0.tgz",
+      "integrity": "sha512-3ClE3wgN/Zw0ahfVAY5KQ/y3K2c+SYHwVUQaGSuVQlPOCDInGYjE/XEFwCeGJzncRPHIKDRPEsHCpm1uwgwEqQ==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.170.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.170.0.tgz",
+      "integrity": "sha512-VV6lfss6Go00TF2hRVJnN8Uf2FOwC++1e8glaeU7fMWluYCBjwl+116mPOPFaxvkJCg0dui2tFroXioslM/rvQ==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.180.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.180.0.tgz",
+      "integrity": "sha512-XGq/RUuhqnLlApETBmBWDszNG4TR3FCOSNwFvok1UIPgFXxjh0JOzNc5mAX1St2hfx1IDb9Ja4BmTkYKix7byg==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.180.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.180.0.tgz",
+      "integrity": "sha512-ch9VR4OKYGEaNbLhX/EyZDpNZst5T+/VYsFyqMA47J0YyMbg7GWyn2FjjhZ7qOV3XU6W8YEBNdd7U/LFFVp8uA==",
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.178.0",
+        "@aws-sdk/credential-provider-imds": "3.178.0",
+        "@aws-sdk/node-config-provider": "3.178.0",
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.170.0.tgz",
+      "integrity": "sha512-BDYyMqaxX4/N7rYOIYlqgpZaBuHw3kNXKgOkWtJdzndIZbQX8HnyJ+rF0Pr1aVsOpVDM+fY1prERleFh/ZRTCg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.170.0.tgz",
+      "integrity": "sha512-uQvn3ZaAokWcNSY+tNR71RGXPPncv5ejrpGa/MGOCioeBjkU5n5OJp7BdaTGouZu4fffeVpdZJ/ZNld8LWMgLw==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-middleware": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.178.0.tgz",
+      "integrity": "sha512-93WgrJKuwtv3f2r1Q04emzjMiwpYR5hysOHKMkrGOvAVZdDqe1UTjmtuxQadVi3DBr1KOT/d5uP9MjV8LqaUUA==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.170.0.tgz",
+      "integrity": "sha512-Fof0urZ3Lx6z6LNKSEO6T4DNaNh6sLJaSWFaC6gtVDPux/C3R7wy2RQRDp0baHxE8m1KMB0XnKzHizJNrbDI1w==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.178.0.tgz",
+      "integrity": "sha512-LxOrn7Ai88n0i5J5rTb5Bt0TAycPvDYzjdCwmd2mahsPHZGSDLeCeh6KOIxZsEfnzYRl4HGWvIEXdHIYZ3RTug==",
+      "dependencies": {
+        "@aws-sdk/types": "3.178.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.178.0.tgz",
+      "integrity": "sha512-TrP6v+V4Qnv3E9CNgwR/G+1xiy8fa9j5LAm43qwp9PfJHchNyWOJ0FURD3Ne2sm/388Ybzjb1DRYRZ7B+xbnOw==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.170.0.tgz",
+      "integrity": "sha512-tJby9krepSwDsBK+KQF5ACacZQ4LH1Aheh5Dy0pghxsN/9IRw7kMWTumuRCnSntLFFphDD7GM494/Dvnl1UCLA==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-node": {
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.170.0.tgz",
+      "integrity": "sha512-52QWGNoNQoyT2CuoQz6LjBKxHQtN/ceMFLW+9J1E0I1ni8XTuTYP52BlMe5484KkmZKsHOm+EWe4xuwwVetTxg==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.170.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-waiter": {
+      "version": "3.180.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.180.0.tgz",
+      "integrity": "sha512-fDBGplYp6pIIfrB7073tUhU4zppRaSiPjBCCT00yth9woWwZPUCIg7iQZKEqkBmvCzcJSYn0jRopLhf3Y7i5Wg==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1847,6 +2732,11 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2486,6 +3376,14 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
+    "node_modules/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -3063,6 +3961,18 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
+      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==",
+      "bin": {
+        "xml2js": "cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
+      }
     },
     "node_modules/fastq": {
       "version": "1.13.0",
@@ -6390,8 +7300,7 @@
     "node_modules/tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/tunnel": {
       "version": "0.0.6",
@@ -6881,6 +7790,746 @@
       "dev": true,
       "requires": {
         "@jridgewell/trace-mapping": "^0.3.0"
+      }
+    },
+    "@aws-crypto/ie11-detection": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
+      "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/sha256-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
+      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+      "requires": {
+        "@aws-crypto/ie11-detection": "^2.0.0",
+        "@aws-crypto/sha256-js": "^2.0.0",
+        "@aws-crypto/supports-web-crypto": "^2.0.0",
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/sha256-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
+      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+      "requires": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/supports-web-crypto": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
+      "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/util": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
+      "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
+      "requires": {
+        "@aws-sdk/types": "^3.110.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/abort-controller": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.178.0.tgz",
+      "integrity": "sha512-ptDkCB06BJrYdhKzamM9yI15LxcGkPczY80hzKAY/aecm09alnW27uCt5HJJx2nCd18IUH28ZO1sc7DTLOWb3A==",
+      "requires": {
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-ssm": {
+      "version": "3.181.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.181.0.tgz",
+      "integrity": "sha512-slaAaZccbJeyMqONp+Q04+fE2KCeMXYv38Syc/cFD8eL1jZsCdGa4MqBJ1z95YnHsvMsc18UBgUIOeGiIlpxCg==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.181.0",
+        "@aws-sdk/config-resolver": "3.178.0",
+        "@aws-sdk/credential-provider-node": "3.181.0",
+        "@aws-sdk/fetch-http-handler": "3.178.0",
+        "@aws-sdk/hash-node": "3.178.0",
+        "@aws-sdk/invalid-dependency": "3.178.0",
+        "@aws-sdk/middleware-content-length": "3.178.0",
+        "@aws-sdk/middleware-host-header": "3.178.0",
+        "@aws-sdk/middleware-logger": "3.178.0",
+        "@aws-sdk/middleware-recursion-detection": "3.178.0",
+        "@aws-sdk/middleware-retry": "3.178.0",
+        "@aws-sdk/middleware-serde": "3.178.0",
+        "@aws-sdk/middleware-signing": "3.179.0",
+        "@aws-sdk/middleware-stack": "3.178.0",
+        "@aws-sdk/middleware-user-agent": "3.178.0",
+        "@aws-sdk/node-config-provider": "3.178.0",
+        "@aws-sdk/node-http-handler": "3.178.0",
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/smithy-client": "3.180.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/url-parser": "3.178.0",
+        "@aws-sdk/util-base64-browser": "3.170.0",
+        "@aws-sdk/util-base64-node": "3.170.0",
+        "@aws-sdk/util-body-length-browser": "3.170.0",
+        "@aws-sdk/util-body-length-node": "3.170.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.180.0",
+        "@aws-sdk/util-defaults-mode-node": "3.180.0",
+        "@aws-sdk/util-user-agent-browser": "3.178.0",
+        "@aws-sdk/util-user-agent-node": "3.178.0",
+        "@aws-sdk/util-utf8-browser": "3.170.0",
+        "@aws-sdk/util-utf8-node": "3.170.0",
+        "@aws-sdk/util-waiter": "3.180.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
+      }
+    },
+    "@aws-sdk/client-sso": {
+      "version": "3.181.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.181.0.tgz",
+      "integrity": "sha512-p/HsYVAO7fgjFfn4LqlnlpSKPXGPegAwjPpY+SqyK3/Hj1OtED4whG8LTgxZSTtYwNIkHEjrHnXTiymyXh34Aw==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.178.0",
+        "@aws-sdk/fetch-http-handler": "3.178.0",
+        "@aws-sdk/hash-node": "3.178.0",
+        "@aws-sdk/invalid-dependency": "3.178.0",
+        "@aws-sdk/middleware-content-length": "3.178.0",
+        "@aws-sdk/middleware-host-header": "3.178.0",
+        "@aws-sdk/middleware-logger": "3.178.0",
+        "@aws-sdk/middleware-recursion-detection": "3.178.0",
+        "@aws-sdk/middleware-retry": "3.178.0",
+        "@aws-sdk/middleware-serde": "3.178.0",
+        "@aws-sdk/middleware-stack": "3.178.0",
+        "@aws-sdk/middleware-user-agent": "3.178.0",
+        "@aws-sdk/node-config-provider": "3.178.0",
+        "@aws-sdk/node-http-handler": "3.178.0",
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/smithy-client": "3.180.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/url-parser": "3.178.0",
+        "@aws-sdk/util-base64-browser": "3.170.0",
+        "@aws-sdk/util-base64-node": "3.170.0",
+        "@aws-sdk/util-body-length-browser": "3.170.0",
+        "@aws-sdk/util-body-length-node": "3.170.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.180.0",
+        "@aws-sdk/util-defaults-mode-node": "3.180.0",
+        "@aws-sdk/util-user-agent-browser": "3.178.0",
+        "@aws-sdk/util-user-agent-node": "3.178.0",
+        "@aws-sdk/util-utf8-browser": "3.170.0",
+        "@aws-sdk/util-utf8-node": "3.170.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-sts": {
+      "version": "3.181.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.181.0.tgz",
+      "integrity": "sha512-j//F9kjdSv9lUa8p87cg+xk6l5E8o8+GTYP5838eFQR7XcEc3yEljSCkuj2xIzrtf1jKuMXBnswTKmxJhjbTzQ==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.178.0",
+        "@aws-sdk/credential-provider-node": "3.181.0",
+        "@aws-sdk/fetch-http-handler": "3.178.0",
+        "@aws-sdk/hash-node": "3.178.0",
+        "@aws-sdk/invalid-dependency": "3.178.0",
+        "@aws-sdk/middleware-content-length": "3.178.0",
+        "@aws-sdk/middleware-host-header": "3.178.0",
+        "@aws-sdk/middleware-logger": "3.178.0",
+        "@aws-sdk/middleware-recursion-detection": "3.178.0",
+        "@aws-sdk/middleware-retry": "3.178.0",
+        "@aws-sdk/middleware-sdk-sts": "3.179.0",
+        "@aws-sdk/middleware-serde": "3.178.0",
+        "@aws-sdk/middleware-signing": "3.179.0",
+        "@aws-sdk/middleware-stack": "3.178.0",
+        "@aws-sdk/middleware-user-agent": "3.178.0",
+        "@aws-sdk/node-config-provider": "3.178.0",
+        "@aws-sdk/node-http-handler": "3.178.0",
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/smithy-client": "3.180.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/url-parser": "3.178.0",
+        "@aws-sdk/util-base64-browser": "3.170.0",
+        "@aws-sdk/util-base64-node": "3.170.0",
+        "@aws-sdk/util-body-length-browser": "3.170.0",
+        "@aws-sdk/util-body-length-node": "3.170.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.180.0",
+        "@aws-sdk/util-defaults-mode-node": "3.180.0",
+        "@aws-sdk/util-user-agent-browser": "3.178.0",
+        "@aws-sdk/util-user-agent-node": "3.178.0",
+        "@aws-sdk/util-utf8-browser": "3.170.0",
+        "@aws-sdk/util-utf8-node": "3.170.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/config-resolver": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.178.0.tgz",
+      "integrity": "sha512-8xL98TGMaVULIN7HRWV2q1o0Y2p38QuweehzM8yXCZrrLOyHgWo3waP2RNVeddOB7MrSwwU/gw9rXSv7YHLZ6w==",
+      "requires": {
+        "@aws-sdk/signature-v4": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-config-provider": "3.170.0",
+        "@aws-sdk/util-middleware": "3.178.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-env": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.178.0.tgz",
+      "integrity": "sha512-5CMswTJ188RuK9TmI5yAosIsyu4Mm9Cdq1068tRls5EqqwGK1PI7Q007b6rD7zqCb5IgeFBV0t2DxHkBmHRd3w==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-imds": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.178.0.tgz",
+      "integrity": "sha512-ZvqQTi3+S13LACVgaWNCOKBv5jROIz7rqyZh56QunAkaAUqPbpM4VFODgAGZYPCOSggZbEUUqXOVB9xSnshLnA==",
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.178.0",
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/url-parser": "3.178.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-ini": {
+      "version": "3.181.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.181.0.tgz",
+      "integrity": "sha512-jOa42qYFgkdMumw0IRO0ASAjM0vZMXvPpy3DGOaG0Ehy4KHeykEj4/J23SxCTCkOqAbz2+8XVCuyTExUmWCuWw==",
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.178.0",
+        "@aws-sdk/credential-provider-imds": "3.178.0",
+        "@aws-sdk/credential-provider-sso": "3.181.0",
+        "@aws-sdk/credential-provider-web-identity": "3.178.0",
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/shared-ini-file-loader": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-node": {
+      "version": "3.181.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.181.0.tgz",
+      "integrity": "sha512-RlLdp+7faCKzJsmUlBSr4CjqN9WG+YZpmuVVlW5fXGUdXLBLEvLMTl5rmwKtRSUytyYK0Vqtmt48I4nBze8MrA==",
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.178.0",
+        "@aws-sdk/credential-provider-imds": "3.178.0",
+        "@aws-sdk/credential-provider-ini": "3.181.0",
+        "@aws-sdk/credential-provider-process": "3.178.0",
+        "@aws-sdk/credential-provider-sso": "3.181.0",
+        "@aws-sdk/credential-provider-web-identity": "3.178.0",
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/shared-ini-file-loader": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-process": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.178.0.tgz",
+      "integrity": "sha512-J4TldKrAnfayvRfxNEnLJUnTgkpTcct6rc7PwZlVSGSUgjglbcqfemUOP/pisLKbVNNL742lsUXmkUVH4km0Fw==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/shared-ini-file-loader": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-sso": {
+      "version": "3.181.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.181.0.tgz",
+      "integrity": "sha512-03YAvns+P7hw5rLwYLExezn9iGX9HD2GAKCEgpSaZSlNLzMw0jU7VEmqJvrLqi+xAoshuRR5A3v8HFQU246QRA==",
+      "requires": {
+        "@aws-sdk/client-sso": "3.181.0",
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/shared-ini-file-loader": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-web-identity": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.178.0.tgz",
+      "integrity": "sha512-aei8o9ALtzwgYsZCAWdr+ItJyYTkYRmCoKstM4mkGtWNK9BjdISaVUAnndl6Pc/l/5eiK+2rlA+6Ujs4H8m+XQ==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/fetch-http-handler": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.178.0.tgz",
+      "integrity": "sha512-T/LCNwCihdVNzGn39Dw7tk2U1fMlupFlCsAvDBbO+FOM3h+y9WLHzxmlAVsjPrFXlzdONKf9zd5cuQ+ZW93yAQ==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/querystring-builder": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-base64-browser": "3.170.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/hash-node": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.178.0.tgz",
+      "integrity": "sha512-mqYraRQlvPO5egUKTNZ1kP52sfwBlsz7woOewQTHOGomZBDXrh8bl1J+sgaDi1NAwXdZUgxuD3QKxxAKRs9a2Q==",
+      "requires": {
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-buffer-from": "3.170.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/invalid-dependency": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.178.0.tgz",
+      "integrity": "sha512-JJNaiLr3nbRYym6oUAAaoFFYtDnIZ9Scco2p4sG/thT2eyAfXcEdNl1cSD3E/R1J+Ml/YplqTiIY4u1KPAriRw==",
+      "requires": {
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/is-array-buffer": {
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.170.0.tgz",
+      "integrity": "sha512-yYXqgp8rilBckIvNRs22yAXHKcXb86/g+F+hsTZl38OJintTsLQB//O5v6EQTYhSW7T3wMe1NHDrjZ+hFjAy4Q==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-content-length": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.178.0.tgz",
+      "integrity": "sha512-p3n3IzU03eRzZivEoQn1HA83LbAKukZwRevsJpya1UfCUtWkXQO3v0jU8rhZE4deGa9k7zuCAEmJ8nCw3QxclQ==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-host-header": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.178.0.tgz",
+      "integrity": "sha512-EFc9S63iwCmudVpVSiVPiTnp6WCfsRYUmTrZJJouZzthEhJwcrunwu7Fa9lHYb0zcWLgVFLhzs1Z34J/Er4JoQ==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-logger": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.178.0.tgz",
+      "integrity": "sha512-k4jnB+ryGiAhv6vyNFz2YoaVodldjkbz4mqDlVzhwEn77LT/TcwdBoown3cJD/45LEtiuPqeONoTcNCsuCkRFQ==",
+      "requires": {
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-recursion-detection": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.178.0.tgz",
+      "integrity": "sha512-dVgSoP2Mer8A0JGaWgpC/f4vPyvHh7laES/u5sTy6RfwrR87oTx+uhKrc6eh+9NkMR2xdRyaNJAMIXwL5bsVzg==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-retry": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.178.0.tgz",
+      "integrity": "sha512-glBXpAqt+4KQ7q8y2/kwDX2ujCvCSQok5rlAmUjaQjVPc3cX77QwATIRQTS2nBC4v9tfMc7yL64ZeRbx6n0RAQ==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/service-error-classification": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-middleware": "3.178.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-sdk-sts": {
+      "version": "3.179.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.179.0.tgz",
+      "integrity": "sha512-uU9UdG9ornvblXdLLNsZNpgMOA9vgFMB93zo3DL/Q6MPmYprZYyK7dUiA06i1pe4HP2gR3N3hxXwzmKU6Bjt6A==",
+      "requires": {
+        "@aws-sdk/middleware-signing": "3.179.0",
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/signature-v4": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-serde": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.178.0.tgz",
+      "integrity": "sha512-TERiu/B4hYi5Jd4iQN9ECTWbt2IZweAgFB010MboM4CAPm6EcszEc/uCB4faLZNdJaksk1BhAR7koURcda8Sew==",
+      "requires": {
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-signing": {
+      "version": "3.179.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.179.0.tgz",
+      "integrity": "sha512-rtB6t3w1Km3ngO1yoiEUqsobujcBk36oPs2fTUKTbmuTr+54YH3NF0zAwVJv08lpfAs56holtp+bYyAxZJIxSQ==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/signature-v4": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-middleware": "3.178.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-stack": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.178.0.tgz",
+      "integrity": "sha512-ELYM5Imhlcz2zT1Z4OjVZwO564KvI4L9dMBxuUgO0fwommzjWqxR03yaRGhpGwpCP64d0Op5Koc/RKq5V92Wbw==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-user-agent": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.178.0.tgz",
+      "integrity": "sha512-xkKBxrFbs+UwUPpfIGEPuHeBWS2Jgmcd+ipEJUQRR3lY4h1fJ6mPGeyyaVDvwaJp9KgESSI6QTp6V15l8GXXgQ==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/node-config-provider": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.178.0.tgz",
+      "integrity": "sha512-yb5XJcC7SxkZ5oxu3zQ/foBdMkLBKryzx/CVg5BNSsKDjfbouf/ZYPcJDHhc2gzCtZcx18GjFBOnv8cpo/tyXQ==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/shared-ini-file-loader": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/node-http-handler": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.178.0.tgz",
+      "integrity": "sha512-EtH6YiX1IX0QraQ/+kKBWAEtsFYBnFyxOimTBtlpDYwFpgDzIZ1GFn2wORYomEWALg10kphs8n3E5/7b5t5OWQ==",
+      "requires": {
+        "@aws-sdk/abort-controller": "3.178.0",
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/querystring-builder": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/property-provider": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.178.0.tgz",
+      "integrity": "sha512-+Fh1aUANa+Gt/rh4SUHO0yHwKsibyZGk2LLDUcM1+9r0pUZT0qy3h0UCl5Kkj9HUcDJMD73wHTx4UB440xRobw==",
+      "requires": {
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/protocol-http": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.178.0.tgz",
+      "integrity": "sha512-GsnANW60mVYMlE16UGNSOwYZ6TbkoODvmDQi95SEPjM7asf4vihEyDvhxiGS/JvC18UyxRVWT89l/V3hR/SF7w==",
+      "requires": {
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/querystring-builder": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.178.0.tgz",
+      "integrity": "sha512-vJXlExSshlHtGVvan/U6JihWvzf8t9QwH5I4F6HUY+exxMy5vFDYCnNqGAzbJwq7w/HME1gQWLoXq2k0uODz7g==",
+      "requires": {
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-uri-escape": "3.170.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/querystring-parser": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.178.0.tgz",
+      "integrity": "sha512-dp3pLnsOvAcIF7Yn2PY5CIVWX7GvC33nSlWDYeLeCMapccwTbe6zBqreWbScmIGJra4QJTdjccpwo2Yxwhr5QQ==",
+      "requires": {
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/service-error-classification": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.178.0.tgz",
+      "integrity": "sha512-tDKTBXxck2N4bhAnQaeokx9ps38V3G70lcDdHS/N9hmqcQQmH5x+1/AMwYWLjUZmOQPBW9sFoG4B3psnl+sefw=="
+    },
+    "@aws-sdk/shared-ini-file-loader": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.178.0.tgz",
+      "integrity": "sha512-nZGmuhGLDFbXsb7QYDg7PiPMAmsdlSshKJ+AhKSZF/J0SK94kdZgGnGXGUZe52S3G41E3CZIgnLnnsMXq0uErA==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/signature-v4": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.178.0.tgz",
+      "integrity": "sha512-8oOx6o0uOqlCDPM0dszfR1WHqd0E1VuFqez8iNItp0DhmhaCuanEwKYYA6HOkVu/MA6CsG6zDIJaFr5ODU2NvQ==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.170.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-hex-encoding": "3.170.0",
+        "@aws-sdk/util-middleware": "3.178.0",
+        "@aws-sdk/util-uri-escape": "3.170.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/smithy-client": {
+      "version": "3.180.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.180.0.tgz",
+      "integrity": "sha512-1vWafiUdn6RvOsD4CyNjMeDtDujuPi4Iq4Db6HrFmVPpJAutOLlCg52Dt7k96KCcIKgxVAs6Br0Waef+pcoGNA==",
+      "requires": {
+        "@aws-sdk/middleware-stack": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/types": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.178.0.tgz",
+      "integrity": "sha512-CrHxHzXSEr/Z3NLFvJgSGHGcD9tYUZ0Rhp8tFCSpD3TpBo3/Y7RIvqaEPvECsL52UEloeBhQf65AO8590YkVmQ=="
+    },
+    "@aws-sdk/url-parser": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.178.0.tgz",
+      "integrity": "sha512-+Ch29d+IZG6zD1gNDVgFC00huY8ytrPdijAuNJ4DtPBTGP4zbrImw3js0GfvfBjLrQYBnclcAvSx4J1Q/8tqBQ==",
+      "requires": {
+        "@aws-sdk/querystring-parser": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-base64-browser": {
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.170.0.tgz",
+      "integrity": "sha512-uLP9Kp74+jc+UWI392LSWIaUj9eXZBhkAiSm8dXAyrr+5GFOKvmEdidFoZKKcFcZ2v3RMonDgFVcDBiZ33w7BQ==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-base64-node": {
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.170.0.tgz",
+      "integrity": "sha512-sjpOmfyW0RWCLXU8Du0ZtwgFoxIuKQIyVygXJ4qxByoa3jIUJXf4U33uSRMy47V3JoogdZuKSpND9hiNk2wU4w==",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.170.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-body-length-browser": {
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.170.0.tgz",
+      "integrity": "sha512-SqSWA++gsZgHw6tlcEXx9K6R6cVKNYzOq6bca+NR7jXvy1hfqiv9Gx5TZrG4oL4JziP8QA0fTklmI1uQJ4HBRA==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-body-length-node": {
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.170.0.tgz",
+      "integrity": "sha512-sFb85ngsgfpamwDn22LC/+FkbDTNiddbMHptkajw+CAD2Rb4SJDp2PfXZ6k883BueJWhmxZ9+lApHZqYtgPdzw==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-buffer-from": {
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.170.0.tgz",
+      "integrity": "sha512-3ClE3wgN/Zw0ahfVAY5KQ/y3K2c+SYHwVUQaGSuVQlPOCDInGYjE/XEFwCeGJzncRPHIKDRPEsHCpm1uwgwEqQ==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.170.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-config-provider": {
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.170.0.tgz",
+      "integrity": "sha512-VV6lfss6Go00TF2hRVJnN8Uf2FOwC++1e8glaeU7fMWluYCBjwl+116mPOPFaxvkJCg0dui2tFroXioslM/rvQ==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.180.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.180.0.tgz",
+      "integrity": "sha512-XGq/RUuhqnLlApETBmBWDszNG4TR3FCOSNwFvok1UIPgFXxjh0JOzNc5mAX1St2hfx1IDb9Ja4BmTkYKix7byg==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-defaults-mode-node": {
+      "version": "3.180.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.180.0.tgz",
+      "integrity": "sha512-ch9VR4OKYGEaNbLhX/EyZDpNZst5T+/VYsFyqMA47J0YyMbg7GWyn2FjjhZ7qOV3XU6W8YEBNdd7U/LFFVp8uA==",
+      "requires": {
+        "@aws-sdk/config-resolver": "3.178.0",
+        "@aws-sdk/credential-provider-imds": "3.178.0",
+        "@aws-sdk/node-config-provider": "3.178.0",
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-hex-encoding": {
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.170.0.tgz",
+      "integrity": "sha512-BDYyMqaxX4/N7rYOIYlqgpZaBuHw3kNXKgOkWtJdzndIZbQX8HnyJ+rF0Pr1aVsOpVDM+fY1prERleFh/ZRTCg==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-locate-window": {
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.170.0.tgz",
+      "integrity": "sha512-uQvn3ZaAokWcNSY+tNR71RGXPPncv5ejrpGa/MGOCioeBjkU5n5OJp7BdaTGouZu4fffeVpdZJ/ZNld8LWMgLw==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-middleware": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.178.0.tgz",
+      "integrity": "sha512-93WgrJKuwtv3f2r1Q04emzjMiwpYR5hysOHKMkrGOvAVZdDqe1UTjmtuxQadVi3DBr1KOT/d5uP9MjV8LqaUUA==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-uri-escape": {
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.170.0.tgz",
+      "integrity": "sha512-Fof0urZ3Lx6z6LNKSEO6T4DNaNh6sLJaSWFaC6gtVDPux/C3R7wy2RQRDp0baHxE8m1KMB0XnKzHizJNrbDI1w==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-user-agent-browser": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.178.0.tgz",
+      "integrity": "sha512-LxOrn7Ai88n0i5J5rTb5Bt0TAycPvDYzjdCwmd2mahsPHZGSDLeCeh6KOIxZsEfnzYRl4HGWvIEXdHIYZ3RTug==",
+      "requires": {
+        "@aws-sdk/types": "3.178.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-user-agent-node": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.178.0.tgz",
+      "integrity": "sha512-TrP6v+V4Qnv3E9CNgwR/G+1xiy8fa9j5LAm43qwp9PfJHchNyWOJ0FURD3Ne2sm/388Ybzjb1DRYRZ7B+xbnOw==",
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-utf8-browser": {
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.170.0.tgz",
+      "integrity": "sha512-tJby9krepSwDsBK+KQF5ACacZQ4LH1Aheh5Dy0pghxsN/9IRw7kMWTumuRCnSntLFFphDD7GM494/Dvnl1UCLA==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-utf8-node": {
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.170.0.tgz",
+      "integrity": "sha512-52QWGNoNQoyT2CuoQz6LjBKxHQtN/ceMFLW+9J1E0I1ni8XTuTYP52BlMe5484KkmZKsHOm+EWe4xuwwVetTxg==",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.170.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-waiter": {
+      "version": "3.180.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.180.0.tgz",
+      "integrity": "sha512-fDBGplYp6pIIfrB7073tUhU4zppRaSiPjBCCT00yth9woWwZPUCIg7iQZKEqkBmvCzcJSYn0jRopLhf3Y7i5Wg==",
+      "requires": {
+        "@aws-sdk/abort-controller": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       }
     },
     "@babel/code-frame": {
@@ -8246,6 +9895,11 @@
         }
       }
     },
+    "bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -8720,6 +10374,11 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
+    "entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+    },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -9048,6 +10707,11 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fast-xml-parser": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
+      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg=="
     },
     "fastq": {
       "version": "1.13.0",
@@ -11523,8 +13187,7 @@
     "tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "tunnel": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -17,19 +17,20 @@
   "dependencies": {
     "@actions/artifact": "^1.1.0",
     "@actions/core": "^1.6.0",
+    "@aws-sdk/client-ssm": "^3.181.0",
     "esbuild": "^0.14.29",
     "js-yaml": "^4.1.0"
   },
   "devDependencies": {
+    "@guardian/cdk": "46.0.1",
     "@types/jest": "^27.4.1",
     "@types/js-yaml": "^4.0.5",
     "@types/node": "^17.0.23",
+    "aws-cdk-lib": "2.29.1",
+    "constructs": "10.1.42",
     "jest": "^27.5.1",
     "prettier": "2.7.1",
     "ts-jest": "^27.1.4",
-    "typescript": "^4.6.3",
-    "aws-cdk-lib": "2.29.1",
-    "constructs": "10.1.42",
-    "@guardian/cdk": "46.0.1"
+    "typescript": "^4.6.3"
   }
 }

--- a/role.yaml
+++ b/role.yaml
@@ -1,0 +1,39 @@
+Parameters:
+  GitHubOidcArn:
+    Type: String
+    Description: ARN of existing Github Open ID Connect Provider
+
+Resources:
+  # Resources to provide SSM Parameter store write permissions.
+  Policy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: ActionsStaticSitePutParameterPolicy
+      PolicyDocument:
+        Statement:
+          Action:
+            - ssm:PutParameter
+          Effect: Allow
+          Resource:
+            - !Sub arn:aws:ssm:eu-west-1:${AWS::AccountId}:parameter/actions-static-site/*
+      Roles:
+        - Ref: Role
+
+  Role:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRoleWithWebIdentity
+            Principal:
+              Federated: !Ref GitHubOidcArn
+            Condition:
+              StringLike:
+                # All GitHub Actions running in repositories within the Guardian GitHub organisation.
+                token.actions.githubusercontent.com:sub: repo:guardian/*
+
+Outputs:
+  Role:
+    # To be set as an organisational secret in GitHub Actions (`GU_ACTIONS_STATIC_SITE_ROLE_ARN`).
+    Value: !GetAtt Role.Arn


### PR DESCRIPTION
Rather than requesting users manually add these we accept them as (secret) inputs and write them to parameter store as part of the action.

The `role.yaml` file defines the Cloudformation template for the role used by GHA to write to parameter store.
