### PR TITLE
Fix no-auth case - following devx.gutools.co.uk errors

### DIFF
--- a/cdk/__snapshots__/static-site.test.ts.snap
+++ b/cdk/__snapshots__/static-site.test.ts.snap
@@ -257,6 +257,11 @@ Object {
           },
           "S3Key": "stack/PROD/app/lambda.zip",
         },
+        "Environment": Object {
+          "Variables": Object {
+            "AUTH": "google",
+          },
+        },
         "Handler": "main",
         "Layers": Array [
           Object {

--- a/cdk/static-site.ts
+++ b/cdk/static-site.ts
@@ -64,6 +64,9 @@ export class StaticSite extends GuStack {
       handler: "main",
       code: Code.fromBucket(bucket, `${s3Prefix}/lambda.zip`),
       layers: [siteLayer],
+      environment: {
+        AUTH: props.auth ? "google" : "none"
+      }
     });
 
     const vpc = GuVpc.fromIdParameter(this, "vpc-id");

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -22,9 +22,14 @@ func (ie InvalidEmail) Error() string {
 }
 
 func main() {
-
+	isGoogleAuth := os.Getenv("AUTH") == "google"
 	fs := http.FileServer(http.Dir("/opt/site"))
-	http.Handle("/", withAuth(fs))
+
+	if isGoogleAuth {
+		http.Handle("/", withAuth(fs))
+	} else {
+		http.Handle("/", fs)
+	}
 
 	// http.ListenAndServe("localhost:3030", nil)
 	algnhsa.ListenAndServe(nil, nil)


### PR DESCRIPTION
Currently seeing 403 errors for devx.gutools.co.uk. This PR fixes this by correctly handling no-auth cases in the Go code.