### PR TITLE
Build & zip lambda in CI

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -40,13 +40,13 @@ runs:
         role-to-assume: ${{ inputs.guActionsStaticSiteRoleArn }}
 
     - uses: actions/setup-go@v3
-        with:
-          go-version: "1.18"
-      - name: Run tests
-        run: |
-          cd lambda
-          GOOS=linux GOARCH=amd64 go build main.go
-          zip lambda.zip main
+      with:
+        go-version: "1.18"
+    - name: Build lambda
+      run: |
+        cd lambda
+        GOOS=linux GOARCH=amd64 go build main.go
+        zip lambda.zip main
 
     - name: CDK synth
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -43,6 +43,7 @@ runs:
       with:
         go-version: "1.18"
     - name: Build lambda
+      shell: bash
       run: |
         cd lambda
         GOOS=linux GOARCH=amd64 go build main.go

--- a/action.yaml
+++ b/action.yaml
@@ -39,6 +39,15 @@ runs:
         aws-region: eu-west-1
         role-to-assume: ${{ inputs.guActionsStaticSiteRoleArn }}
 
+    - uses: actions/setup-go@v3
+        with:
+          go-version: "1.18"
+      - name: Run tests
+        run: |
+          cd lambda
+          GOOS=linux GOARCH=amd64 go build main.go
+          zip lambda.zip main
+
     - name: CDK synth
       shell: bash
       run: |

--- a/lambda/README.md
+++ b/lambda/README.md
@@ -7,5 +7,5 @@ The expectation is that the static site is loaded as a layer.
 
 To rebuild the binary run:
 
-    $ GOOS=linux GOARCH=amd64 go build main.go
-    $ zip lambda.zip main
+    $ go build
+


### PR DESCRIPTION
## What does this change?

This change builds the lambda in CI, removing the need to remember to do this manually and commit the binary.