### PR TITLE
Fix build as part of action

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -39,6 +39,9 @@ runs:
         aws-region: eu-west-1
         role-to-assume: ${{ inputs.guActionsStaticSiteRoleArn }}
 
+    - name: Checkout repo
+      uses: actions/checkout@v3
+
     - uses: actions/setup-go@v3
       with:
         go-version: "1.18"


### PR DESCRIPTION
## What does this change?

This change adds a step to checkout the action code before attempting to do a build. 

Attempting to fix the issue seen here: https://github.com/guardian/devx-docs/actions/runs/3525209803/jobs/5911640225
