### PR TITLE
Revert "Build & zip lambda in CI"

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -39,16 +39,6 @@ runs:
         aws-region: eu-west-1
         role-to-assume: ${{ inputs.guActionsStaticSiteRoleArn }}
 
-    - uses: actions/setup-go@v3
-      with:
-        go-version: "1.18"
-    - name: Build lambda
-      shell: bash
-      run: |
-        cd lambda
-        GOOS=linux GOARCH=amd64 go build main.go
-        zip lambda.zip main
-
     - name: CDK synth
       shell: bash
       run: |

--- a/lambda/README.md
+++ b/lambda/README.md
@@ -7,5 +7,5 @@ The expectation is that the static site is loaded as a layer.
 
 To rebuild the binary run:
 
-    $ go build
-
+    $ GOOS=linux GOARCH=amd64 go build main.go
+    $ zip lambda.zip main


### PR DESCRIPTION
Reverts guardian/actions-static-site#8 as it was causing [build failure downstream](https://github.com/guardian/devx-docs/actions/runs/3525369297/jobs/5912004290#step:6:89).