### PR TITLE
Drop duplicate creds call

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,11 +16,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-region: eu-west-1
-          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-
       - uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'

--- a/README.md
+++ b/README.md
@@ -12,17 +12,42 @@ auth callback to work - ping it on the `DevX Stream` channel and we can quickly
 add this for you.**
 
 ```yaml
-# First upload your site as an artifact:
-- uses: actions/upload-artifact@v3
-  with:
-    path: path/to/site-dir
+name: example
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+jobs:
+  example:
+    runs-on: ubuntu-latest
 
-# Then invoke this action (replacing app and domain)
-- uses: guardian/actions-static-site@v2
-  with:
-    app: devx-docs
-    domain: devx.gutools.co.uk
-    guActionsRiffRaffRoleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+    # Required for Riffraff upload (which writes to AWS)
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+
+      # ... (Buiild your static site.)
+
+      # Then upload it as an artifact
+      - uses: actions/upload-artifact@v3
+        with:
+          path: my-site
+
+      # Then invoke this action (replacing app and domain)
+      - uses: guardian/actions-static-site@v2
+        with:
+          app: devx-docs
+          domain: devx.gutools.co.uk
+          guActionsRiffRaffRoleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
 ```
 
 ## Inputs

--- a/README.md
+++ b/README.md
@@ -29,12 +29,6 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
-        with:
-          node-version-file: '.nvmrc'
-          cache: npm
-
       # ... (Buiild your static site.)
 
       # Then upload it as an artifact
@@ -45,8 +39,8 @@ jobs:
       # Then invoke this action (replacing app and domain)
       - uses: guardian/actions-static-site@v2
         with:
-          app: devx-docs
-          domain: devx.gutools.co.uk
+          app: example
+          domain: example.gutools.co.uk
           guActionsRiffRaffRoleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
 ```
 

--- a/action.yaml
+++ b/action.yaml
@@ -22,11 +22,6 @@ runs:
   # env) so need to be passed them explicitly :(. Sad times I know.
   using: 'composite'
   steps:
-    - uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-region: eu-west-1
-        role-to-assume: ${{ inputs.guActionsStaticSiteRoleArn }}
-
     - name: CDK synth
       shell: bash
       run: |


### PR DESCRIPTION
The action itself should call this. Though note, the permissions are still required so have updated the README.md to make that clear.