### PR TITLE
add bucket resource policy for Galaxies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,10 @@ jobs:
           aws-region: eu-west-1
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
 
+      - uses: guardian/actions-read-private-repos@v0.1.0
+        with:
+          private-ssh-keys: ${{ secrets.PRIVATE_INFRASTRUCTURE_CONFIG_DEPLOY_KEY }}
+
       - uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,6 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: guardian/actions-read-private-repos@v0.1.0
+        with:
+          private-ssh-keys: ${{ secrets.PRIVATE_INFRASTRUCTURE_CONFIG_DEPLOY_KEY }}
+
       - uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'

--- a/cdk/__snapshots__/infra.test.ts.snap
+++ b/cdk/__snapshots__/infra.test.ts.snap
@@ -1174,6 +1174,75 @@ systemctl start app
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Retain",
     },
+    "staticPolicy36384B58": Object {
+      "Properties": Object {
+        "Bucket": Object {
+          "Ref": "staticD8C87B36",
+        },
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:PutObject",
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": "arn:aws:iam::000000000016:role/galaxies-data-refresher-lambda-role-PROD",
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "staticD8C87B36",
+                        "Arn",
+                      ],
+                    },
+                    "/galaxies.gutools.co.uk/data/*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:PutObject",
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Array [
+                  Object {
+                    "Fn::Join": Array [
+                      "",
+                      Array [
+                        "arn:",
+                        Object {
+                          "Ref": "AWS::Partition",
+                        },
+                        ":iam::000000000016:root",
+                      ],
+                    ],
+                  },
+                  "arn:aws:iam::000000000016:role/galaxies-data-refresher-lambda-role-CODE",
+                ],
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "staticD8C87B36",
+                        "Arn",
+                      ],
+                    },
+                    "/galaxies.code.dev-gutools.co.uk/data/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
     "staticsitealbdnsname7E2D6E36": Object {
       "Properties": Object {
         "Description": "ALB DNS name for static sites.",

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,6 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  setupFilesAfterEnv: ["./jest.setup.js"],
+  transformIgnorePatterns: ["node_modules/(?!@guardian/private-infrastructure-config)"]
 };

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+jest.mock("@guardian/private-infrastructure-config");

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@guardian/cdk": "48.5.1",
         "@guardian/eslint-config-typescript": "^1.0.11",
         "@guardian/prettier": "^2.0.0",
+        "@guardian/private-infrastructure-config": "git+ssh://git@github.com/guardian/private-infrastructure-config.git#v2.1.3",
         "@types/jest": "^27.4.1",
         "@types/js-yaml": "^4.0.5",
         "@types/node": "^17.0.23",
@@ -1873,6 +1874,11 @@
       "peerDependencies": {
         "prettier": "^2.4.0"
       }
+    },
+    "node_modules/@guardian/private-infrastructure-config": {
+      "version": "2.1.2",
+      "resolved": "git+ssh://git@github.com/guardian/private-infrastructure-config.git#834dd66e3880defebfc2a0d9a695957dc5e4b89d",
+      "dev": true
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.7",
@@ -10454,6 +10460,11 @@
       "integrity": "sha512-4fehERf5HHS9Nkaw+4u5EZ1OrFEHL4lYhLUWkpwEx4VmHI+RgcMezfDfosb3TD8cPFCKakrpdQEJUwNP283SJw==",
       "dev": true,
       "requires": {}
+    },
+    "@guardian/private-infrastructure-config": {
+      "version": "git+ssh://git@github.com/guardian/private-infrastructure-config.git#834dd66e3880defebfc2a0d9a695957dc5e4b89d",
+      "dev": true,
+      "from": "@guardian/private-infrastructure-config@git+ssh://git@github.com/guardian/private-infrastructure-config.git#v2.1.3"
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.7",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@guardian/cdk": "48.5.1",
     "@guardian/eslint-config-typescript": "^1.0.11",
     "@guardian/prettier": "^2.0.0",
+    "@guardian/private-infrastructure-config": "git+ssh://git@github.com/guardian/private-infrastructure-config.git#v2.1.3",
     "@types/jest": "^27.4.1",
     "@types/js-yaml": "^4.0.5",
     "@types/node": "^17.0.23",


### PR DESCRIPTION
This adds a bucket resource policy to allow the Galaxies data refresher lambda to write JSON to its static site data bucket. (for CODE and PROD). 
Most static sites won't need this kind of permission but given the near-real-time nature of Galaxies' data this is a necessary workaround if we're to take advantage of `actions-static-site`.

A corresponding PR has been set up in the Galaxies repository (https://github.com/guardian/galaxies/pull/78). 