### PR TITLE
Use arm64-focal-java11-deploy-infrastructure as the AMI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,7 @@ jobs:
                   amiParameter: AMIActionsstaticsiteinfra
                   amiTags:
                     BuiltBy: amigo
-                    Recipe: arm64-bionic-java11-deploy-infrastructure
+                    Recipe: arm64-focal-java11-deploy-infrastructure
                     AmigoStage: PROD
               app:
                 app: actions-static-site-infra


### PR DESCRIPTION
## What does this change?

Move to use https://amigo.gutools.co.uk/recipes/arm64-focal-java11-deploy-infrastructure.

This will allow us to:

- Move actions-static-site to 20.04 to avoid the 18.04 EOL
- Test whether the new `arm64-focal-java11-deploy-infrastructure` image is working as expected

## How to test

Deploy this PR to the PROD environment and check the EC2 instances with the new AMI are successfully brought into service & that actions-static-site sites still work.

See: https://riffraff.gutools.co.uk/deployment/view/78f8ad19-d957-4c34-bdfc-d1be4b74ec62

## How can we measure success?

Can we use the focal AMI to successfully deploy actions-static-site?

## Have we considered potential risks?

actions-static-site is not deployable with Focal base AMIs, we'll revert.