### PR TITLE
don't require auth for `**/_prout` (to allow static sites to benefit from PRout)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ for your project. The marginal cost of a site is minimal - just the storage of
 your files in S3 and data transfer costs - as the core infrastructure is shared.
 
 **Note: your domain must be registered with the Google project for the Google
-auth callback to work - ping it on the `DevX Stream` channel and we can quickly
-add this for you.**
+auth callback to work - ping it on the `DevX Stream` channel and we can quickly add this for you.**
+
+Any paths ending in `/_prout` will skip authentication, so feel free to add the git hash as a file called `_prout` and then wire it up to [PRout](https://github.com/guardian/prout) - for example [guardian/galaxies#102](https://github.com/guardian/galaxies/pull/102).
 
 ```yaml
 name: example

--- a/service/middleware/middleware.go
+++ b/service/middleware/middleware.go
@@ -59,6 +59,12 @@ func WithDomainPrefix(h http.Handler) http.HandlerFunc {
 // security step in case the EC2 instance is somehow accessed not via the ALB.
 func WithAuth(h http.Handler) http.HandlerFunc {
 	return func(resp http.ResponseWriter, req *http.Request) {
+	  if strings.HasSuffix(req.URL.Path, "/_prout") {
+	    // https://github.com/guardian/prout needs no auth, so we skip it for **/_prout
+	    h.ServeHTTP(resp, req)
+	    return
+	  }
+
 		// See https://docs.aws.amazon.com/elasticloadbalancing/latest/application/listener-authenticate-users.html#user-claims-encoding
 		tokenString := req.Header.Get("x-amzn-oidc-data")
 		err := auth(tokenString, keyFunc, []string{"ES256"})


### PR DESCRIPTION
[PRout](https://github.com/guardian/prout) is super useful for knowing when your PRs have been deployed. 

This PR aims to establish a convention whereby any files with `_prout` as their filename will be served without requiring auth (so [PRout](https://github.com/guardian/prout) can hit them).

https://github.com/guardian/galaxies/pull/102 is an example of how this is beneficial.