### PR TITLE
skip auth at ALB for path pattern `**/_prout`

### DIFF
--- a/cdk/__snapshots__/infra.test.ts.snap
+++ b/cdk/__snapshots__/infra.test.ts.snap
@@ -708,6 +708,33 @@ systemctl start app
       },
       "Type": "AWS::ElasticLoadBalancingV2::Listener",
     },
+    "ListenerAppPRoutRule52A1A63F": Object {
+      "Properties": Object {
+        "Actions": Array [
+          Object {
+            "TargetGroupArn": Object {
+              "Ref": "TargetGroupAppC3FDB286",
+            },
+            "Type": "forward",
+          },
+        ],
+        "Conditions": Array [
+          Object {
+            "Field": "path-pattern",
+            "PathPatternConfig": Object {
+              "Values": Array [
+                "**/_prout",
+              ],
+            },
+          },
+        ],
+        "ListenerArn": Object {
+          "Ref": "ListenerApp55D0EA9B",
+        },
+        "Priority": 1,
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
+    },
     "LoadBalancerApp94515990": Object {
       "Properties": Object {
         "LoadBalancerAttributes": Array [

--- a/cdk/infra.ts
+++ b/cdk/infra.ts
@@ -14,9 +14,7 @@ import { GuardianAwsAccounts } from "@guardian/private-infrastructure-config";
 import type { App } from "aws-cdk-lib";
 import { Duration, SecretValue } from "aws-cdk-lib";
 import { InstanceClass, InstanceSize, InstanceType, SecurityGroup } from "aws-cdk-lib/aws-ec2";
-import {
-  ListenerAction,
-} from "aws-cdk-lib/aws-elasticloadbalancingv2";
+import { ListenerAction, ListenerCondition } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 import { AccountPrincipal, ArnPrincipal, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { Bucket } from "aws-cdk-lib/aws-s3";
 import { StringParameter } from "aws-cdk-lib/aws-ssm";
@@ -141,6 +139,11 @@ systemctl start ${app}
       userInfoEndpoint: "https://openidconnect.googleapis.com/v1/userinfo",
     });
 
+    ec2.listener.addTargetGroups("PRout", {
+      priority: 1,
+      conditions: [ListenerCondition.pathPatterns(["**/_prout"])],
+      targetGroups: [ec2.targetGroup],
+    });
     ec2.listener.addAction("auth", { action: authAction });
 
     new GuCname(this, 'DNS', {


### PR DESCRIPTION
Turns out https://github.com/guardian/actions-static-site/pull/18...

> [PRout](https://github.com/guardian/prout) is super useful for knowing when your PRs have been deployed. 
> 
> This PR aims to establish a convention whereby any files with `_prout` as their filename will be served without requiring auth (so [PRout](https://github.com/guardian/prout) can hit them).
> 
> https://github.com/guardian/galaxies/pull/102 is an example of how this is beneficial.

...just did this for the fallback for when the ALB hasn't done the auth (which it does say in a comment a few lines above tbf).

CC @frederickobrien 

This PR adds an ALB listener rule, which manifests like this... 
<img width="1260" alt="image" src="https://user-images.githubusercontent.com/19289579/233146465-45382eb7-40e6-477d-b5c1-67bc69ec6699.png">
