### PR TITLE
Block public access to actions-static-site bucket

### DIFF
--- a/cdk/__snapshots__/infra.test.ts.snap
+++ b/cdk/__snapshots__/infra.test.ts.snap
@@ -4,6 +4,7 @@ exports[`static site INFRA should match snapshot 1`] = `
 Object {
   "Metadata": Object {
     "gu:cdk:constructs": Array [
+      "GuS3Bucket",
       "GuDistributionBucketParameter",
       "GuAnghammaradTopicParameter",
       "GuVpcParameter",
@@ -1173,35 +1174,7 @@ systemctl start app
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
-    "staticD8C87B36": Object {
-      "DeletionPolicy": "Retain",
-      "Properties": Object {
-        "Tags": Array [
-          Object {
-            "Key": "gu:cdk:version",
-            "Value": "48.5.1",
-          },
-          Object {
-            "Key": "gu:repo",
-            "Value": "guardian/actions-static-site",
-          },
-          Object {
-            "Key": "Stack",
-            "Value": "stack",
-          },
-          Object {
-            "Key": "Stage",
-            "Value": "INFRA",
-          },
-        ],
-        "WebsiteConfiguration": Object {
-          "IndexDocument": "index.html",
-        },
-      },
-      "Type": "AWS::S3::Bucket",
-      "UpdateReplacePolicy": "Retain",
-    },
-    "staticPolicy36384B58": Object {
+    "staticAppPolicy8865CD33": Object {
       "Properties": Object {
         "Bucket": Object {
           "Ref": "staticD8C87B36",
@@ -1323,6 +1296,44 @@ systemctl start app
         },
       },
       "Type": "AWS::S3::BucketPolicy",
+    },
+    "staticD8C87B36": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "PublicAccessBlockConfiguration": Object {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true,
+        },
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "app",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "48.5.1",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/actions-static-site",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "stack",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "INFRA",
+          },
+        ],
+        "WebsiteConfiguration": Object {
+          "IndexDocument": "index.html",
+        },
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Retain",
     },
     "staticsitealbdnsname7E2D6E36": Object {
       "Properties": Object {

--- a/cdk/infra.ts
+++ b/cdk/infra.ts
@@ -1,27 +1,37 @@
 import { GuEc2App } from '@guardian/cdk';
-import { AccessScope } from "@guardian/cdk/lib/constants";
-import type {
-  GuStackProps
-} from "@guardian/cdk/lib/constructs/core";
+import { AccessScope } from '@guardian/cdk/lib/constants';
+import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import {
-  GuAnghammaradTopicParameter,
-  GuDistributionBucketParameter,
-  GuStack
-} from "@guardian/cdk/lib/constructs/core";
-import { GuCname } from "@guardian/cdk/lib/constructs/dns/";
-import { GuVpc } from "@guardian/cdk/lib/constructs/ec2";
-import { GuardianAwsAccounts } from "@guardian/private-infrastructure-config";
-import type { App } from "aws-cdk-lib";
-import { Duration, SecretValue } from "aws-cdk-lib";
-import { InstanceClass, InstanceSize, InstanceType, SecurityGroup } from "aws-cdk-lib/aws-ec2";
-import { ListenerAction, ListenerCondition } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
-import { AccountPrincipal, ArnPrincipal, PolicyStatement } from 'aws-cdk-lib/aws-iam';
-import { Bucket } from "aws-cdk-lib/aws-s3";
-import { StringParameter } from "aws-cdk-lib/aws-ssm";
+	GuAnghammaradTopicParameter,
+	GuDistributionBucketParameter,
+	GuStack,
+} from '@guardian/cdk/lib/constructs/core';
+import { GuCname } from '@guardian/cdk/lib/constructs/dns/';
+import { GuVpc } from '@guardian/cdk/lib/constructs/ec2';
+import { GuardianAwsAccounts } from '@guardian/private-infrastructure-config';
+import type { App } from 'aws-cdk-lib';
+import { Duration, SecretValue } from 'aws-cdk-lib';
+import {
+	InstanceClass,
+	InstanceSize,
+	InstanceType,
+	SecurityGroup,
+} from 'aws-cdk-lib/aws-ec2';
+import {
+	ListenerAction,
+	ListenerCondition,
+} from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import {
+	AccountPrincipal,
+	ArnPrincipal,
+	PolicyStatement,
+} from 'aws-cdk-lib/aws-iam';
+import { Bucket } from 'aws-cdk-lib/aws-s3';
+import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 
 interface InfraProps extends GuStackProps {
-  app: string;
-  domainName: string;
+	app: string;
+	domainName: string;
 }
 
 // It is surprisingly tricky in AWS to setup a static site, with a custom domain
@@ -42,19 +52,20 @@ interface InfraProps extends GuStackProps {
 //
 // etc.
 export class Infra extends GuStack {
-  constructor(scope: App, id: string, props: InfraProps) {
-    super(scope, id, props);
+	constructor(scope: App, id: string, props: InfraProps) {
+		super(scope, id, props);
 
-    const bucket = new Bucket(this, "static", {
-      websiteIndexDocument: 'index.html',
-    })
+		const bucket = new Bucket(this, 'static', {
+			websiteIndexDocument: 'index.html',
+		});
 
-    const app = props.app;
-    const keyPrefix = `${this.stack}/${this.stage}/${app}`;
-    const port = 9000;
-    const distBucket = GuDistributionBucketParameter.getInstance(this).valueAsString;
+		const app = props.app;
+		const keyPrefix = `${this.stack}/${this.stage}/${app}`;
+		const port = 9000;
+		const distBucket =
+			GuDistributionBucketParameter.getInstance(this).valueAsString;
 
-    const userData = `#!/bin/bash -ev
+		const userData = `#!/bin/bash -ev
 cat << EOF > /etc/systemd/system/${app}.service
 [Unit]
 Description=Static Site service
@@ -73,144 +84,151 @@ chmod +x /${app}
 systemctl start ${app}
 `;
 
-    const ec2 = new GuEc2App(this, {
-      app: app,
-      access: {
-        scope: AccessScope.PUBLIC, // But note, Google auth required.
-      },
-      instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.NANO),
-      applicationPort: port,
-      monitoringConfiguration: {
-        snsTopicName:
-          GuAnghammaradTopicParameter.getInstance(this).valueAsString,
-        unhealthyInstancesAlarm: true,
-        http5xxAlarm: {
-          tolerated5xxPercentage: 1,
-          numberOfMinutesAboveThresholdBeforeAlarm: 60,
-        },
-      },
-      certificateProps: { domainName: props.domainName },
-      scaling: { minimumInstances: 1, maximumInstances: 2 },
-      userData: userData,
-      imageRecipe: 'arm64-bionic-java11-deploy-infrastructure',
-      applicationLogging: { enabled: true },
-    });
+		const ec2 = new GuEc2App(this, {
+			app: app,
+			access: {
+				scope: AccessScope.PUBLIC, // But note, Google auth required.
+			},
+			instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.NANO),
+			applicationPort: port,
+			monitoringConfiguration: {
+				snsTopicName:
+					GuAnghammaradTopicParameter.getInstance(this).valueAsString,
+				unhealthyInstancesAlarm: true,
+				http5xxAlarm: {
+					tolerated5xxPercentage: 1,
+					numberOfMinutesAboveThresholdBeforeAlarm: 60,
+				},
+			},
+			certificateProps: { domainName: props.domainName },
+			scaling: { minimumInstances: 1, maximumInstances: 2 },
+			userData: userData,
+			imageRecipe: 'arm64-bionic-java11-deploy-infrastructure',
+			applicationLogging: { enabled: true },
+		});
 
-    // Need to give the ALB outbound access on 443 for the IdP endpoints.
-    const sg = new SecurityGroup(this, 'ldp-access', {
-      vpc: GuVpc.fromIdParameter(this, 'vpc', {}),
-      allowAllOutbound: true,
-    })
+		// Need to give the ALB outbound access on 443 for the IdP endpoints.
+		const sg = new SecurityGroup(this, 'ldp-access', {
+			vpc: GuVpc.fromIdParameter(this, 'vpc', {}),
+			allowAllOutbound: true,
+		});
 
-    ec2.loadBalancer.addSecurityGroup(sg)
+		ec2.loadBalancer.addSecurityGroup(sg);
 
-    bucket.grantRead(ec2.autoScalingGroup)
+		bucket.grantRead(ec2.autoScalingGroup);
 
-    // Google Auth stuff...
+		// Google Auth stuff...
 
-    const configPrefix = `/${this.stage}/${this.stack}/${app}`;
-    const clientIdPath = `${configPrefix}/googleClientID`;
+		const configPrefix = `/${this.stage}/${this.stack}/${app}`;
+		const clientIdPath = `${configPrefix}/googleClientID`;
 
-    const clientId = StringParameter.fromStringParameterAttributes(this, "clientID", {
-      parameterName: clientIdPath,
-    }).stringValue;
+		const clientId = StringParameter.fromStringParameterAttributes(
+			this,
+			'clientID',
+			{
+				parameterName: clientIdPath,
+			},
+		).stringValue;
 
-    // Unfortunately, Cloudformation doesn't support directly using secret
-    // Parameter Store values. But it is possible to use Secrets Manager.
-    const secretPath = `${configPrefix}/clientSecret`;
-    const clientSecret = SecretValue.secretsManager(secretPath);
+		// Unfortunately, Cloudformation doesn't support directly using secret
+		// Parameter Store values. But it is possible to use Secrets Manager.
+		const secretPath = `${configPrefix}/clientSecret`;
+		const clientSecret = SecretValue.secretsManager(secretPath);
 
-    const authAction = ListenerAction.authenticateOidc({
-      next: ListenerAction.forward([ec2.targetGroup]),
-      clientId: clientId,
-      clientSecret: clientSecret,
-      scope: "openid email",
+		const authAction = ListenerAction.authenticateOidc({
+			next: ListenerAction.forward([ec2.targetGroup]),
+			clientId: clientId,
+			clientSecret: clientSecret,
+			scope: 'openid email',
 
-      // See the `hd` section of
-      // https://developers.google.com/identity/protocols/oauth2/openid-connect#authenticationuriparameters.
-      // Note, this is NOT sufficient to ensure access is limited to Guardian
-      // emails. Users should also validate the token and check the domain in
-      // their app.
-      authenticationRequestExtraParams: { hd: "guardian.co.uk" },
+			// See the `hd` section of
+			// https://developers.google.com/identity/protocols/oauth2/openid-connect#authenticationuriparameters.
+			// Note, this is NOT sufficient to ensure access is limited to Guardian
+			// emails. Users should also validate the token and check the domain in
+			// their app.
+			authenticationRequestExtraParams: { hd: 'guardian.co.uk' },
 
-      authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
-      issuer: "https://accounts.google.com",
-      tokenEndpoint: "https://oauth2.googleapis.com/token",
-      userInfoEndpoint: "https://openidconnect.googleapis.com/v1/userinfo",
-    });
+			authorizationEndpoint: 'https://accounts.google.com/o/oauth2/v2/auth',
+			issuer: 'https://accounts.google.com',
+			tokenEndpoint: 'https://oauth2.googleapis.com/token',
+			userInfoEndpoint: 'https://openidconnect.googleapis.com/v1/userinfo',
+		});
 
-    ec2.listener.addTargetGroups("PRout", {
-      priority: 1,
-      conditions: [ListenerCondition.pathPatterns(["**/_prout"])],
-      targetGroups: [ec2.targetGroup],
-    });
-    ec2.listener.addAction("auth", { action: authAction });
+		ec2.listener.addTargetGroups('PRout', {
+			priority: 1,
+			conditions: [ListenerCondition.pathPatterns(['**/_prout'])],
+			targetGroups: [ec2.targetGroup],
+		});
+		ec2.listener.addAction('auth', { action: authAction });
 
-    new GuCname(this, 'DNS', {
-      app: app,
-      domainName: props.domainName,
-      resourceRecord: ec2.loadBalancer.loadBalancerDnsName,
-      ttl: Duration.hours(1),
-    });
+		new GuCname(this, 'DNS', {
+			app: app,
+			domainName: props.domainName,
+			resourceRecord: ec2.loadBalancer.loadBalancerDnsName,
+			ttl: Duration.hours(1),
+		});
 
-    // Used in the riff-raff.yaml of static sites to determine the bucket to
-    // upload resources to.
-    new StringParameter(this, 'static-site-bucket', {
-      description: 'Bucket for static sites.',
-      parameterName: `${configPrefix}/bucket`,
-      stringValue: bucket.bucketName,
-    });
+		// Used in the riff-raff.yaml of static sites to determine the bucket to
+		// upload resources to.
+		new StringParameter(this, 'static-site-bucket', {
+			description: 'Bucket for static sites.',
+			parameterName: `${configPrefix}/bucket`,
+			stringValue: bucket.bucketName,
+		});
 
-    // Used by static site Cloudformations to attach certs.
-    new StringParameter(this, 'static-site-alb-dns-name', {
-      description: 'ALB DNS name for static sites.',
-      parameterName: `${configPrefix}/loadBalancerDnsName`,
-      stringValue: ec2.loadBalancer.loadBalancerDnsName,
-    });
+		// Used by static site Cloudformations to attach certs.
+		new StringParameter(this, 'static-site-alb-dns-name', {
+			description: 'ALB DNS name for static sites.',
+			parameterName: `${configPrefix}/loadBalancerDnsName`,
+			stringValue: ec2.loadBalancer.loadBalancerDnsName,
+		});
 
-    new StringParameter(this, 'static-site-lisener-arn', {
-      description: 'Listener ARN for static sites.',
-      parameterName: `${configPrefix}/listenerArn`,
-      stringValue: ec2.listener.listenerArn,
-    });
+		new StringParameter(this, 'static-site-lisener-arn', {
+			description: 'Listener ARN for static sites.',
+			parameterName: `${configPrefix}/listenerArn`,
+			stringValue: ec2.listener.listenerArn,
+		});
 
-    // Grant access to allow Galaxies data-refresher-lambda to write to relevant portion of the bucket
-    // https://github.com/guardian/galaxies
-    Object.values({
-      PROD: {
-        prefix: "galaxies.gutools.co.uk/data/*",
-        principals: [new ArnPrincipal(
-          `arn:aws:iam::${GuardianAwsAccounts.DeveloperPlayground}:role/galaxies-data-refresher-lambda-role-PROD`
-        )]
-      },
-      CODE: {
-        prefix: "galaxies.code.dev-gutools.co.uk/data/*",
-        principals: [
-          new AccountPrincipal(GuardianAwsAccounts.DeveloperPlayground), // for local development
-          new ArnPrincipal(
-            `arn:aws:iam::${GuardianAwsAccounts.DeveloperPlayground}:role/galaxies-data-refresher-lambda-role-CODE`
-          )]
-      }
-    }).forEach(({ principals, prefix }) => {
-      bucket.addToResourcePolicy(
-        new PolicyStatement({
-          resources: [bucket.arnForObjects(prefix)],
-          actions: ["s3:PutObject"],
-          principals: principals
-        })
-      )
-      bucket.addToResourcePolicy(
-        new PolicyStatement({
-          resources: [bucket.bucketArn],
-          actions: ["s3:ListBucket"],
-          principals: principals,
-          conditions: {
-            StringLike: {
-              "s3:prefix": [prefix]
-            }
-          }
-        })
-      )
-    })
-  }
+		// Grant access to allow Galaxies data-refresher-lambda to write to relevant portion of the bucket
+		// https://github.com/guardian/galaxies
+		Object.values({
+			PROD: {
+				prefix: 'galaxies.gutools.co.uk/data/*',
+				principals: [
+					new ArnPrincipal(
+						`arn:aws:iam::${GuardianAwsAccounts.DeveloperPlayground}:role/galaxies-data-refresher-lambda-role-PROD`,
+					),
+				],
+			},
+			CODE: {
+				prefix: 'galaxies.code.dev-gutools.co.uk/data/*',
+				principals: [
+					new AccountPrincipal(GuardianAwsAccounts.DeveloperPlayground), // for local development
+					new ArnPrincipal(
+						`arn:aws:iam::${GuardianAwsAccounts.DeveloperPlayground}:role/galaxies-data-refresher-lambda-role-CODE`,
+					),
+				],
+			},
+		}).forEach(({ principals, prefix }) => {
+			bucket.addToResourcePolicy(
+				new PolicyStatement({
+					resources: [bucket.arnForObjects(prefix)],
+					actions: ['s3:PutObject'],
+					principals: principals,
+				}),
+			);
+			bucket.addToResourcePolicy(
+				new PolicyStatement({
+					resources: [bucket.bucketArn],
+					actions: ['s3:ListBucket'],
+					principals: principals,
+					conditions: {
+						StringLike: {
+							's3:prefix': [prefix],
+						},
+					},
+				}),
+			);
+		});
+	}
 }

--- a/cdk/infra.ts
+++ b/cdk/infra.ts
@@ -8,6 +8,7 @@ import {
 } from '@guardian/cdk/lib/constructs/core';
 import { GuCname } from '@guardian/cdk/lib/constructs/dns/';
 import { GuVpc } from '@guardian/cdk/lib/constructs/ec2';
+import { GuS3Bucket } from '@guardian/cdk/lib/constructs/s3';
 import { GuardianAwsAccounts } from '@guardian/private-infrastructure-config';
 import type { App } from 'aws-cdk-lib';
 import { Duration, SecretValue } from 'aws-cdk-lib';
@@ -26,7 +27,6 @@ import {
 	ArnPrincipal,
 	PolicyStatement,
 } from 'aws-cdk-lib/aws-iam';
-import { Bucket } from 'aws-cdk-lib/aws-s3';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 
 interface InfraProps extends GuStackProps {
@@ -55,11 +55,18 @@ export class Infra extends GuStack {
 	constructor(scope: App, id: string, props: InfraProps) {
 		super(scope, id, props);
 
-		const bucket = new Bucket(this, 'static', {
+		const app = props.app;
+		const bucket = new GuS3Bucket(this, 'static', {
 			websiteIndexDocument: 'index.html',
+			app,
 		});
 
-		const app = props.app;
+		this.overrideLogicalId(bucket, {
+			logicalId: 'staticD8C87B36',
+			reason:
+				'Retaining a stateful resource previously defined as a Bucket, not a GuS3Bucket',
+		});
+
 		const keyPrefix = `${this.stack}/${this.stage}/${app}`;
 		const port = 9000;
 		const distBucket =


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Migrates the static site bucket to use the GuS3Bucket construct. This introduces some security features, such as blocking all public access, that resolve some security alerts

## How to test

Verify CI passes, make sure the changeset contains no destructive operations

## How can we measure success?

The number of open alerts goes down

## Have we considered potential risks?

There is a risk that the bucket, a stateful resource, could be replaced. I believe we have mitigated this risk in the following ways:

- We have preserved the logical ID of the bucket
- Riff raff will not allow a deployment to proceed if it causes the destruction/replacement of an S3 bucket.

