### PR TITLE
Support Galaxies move to hiring/onboarding AWS account

### DIFF
--- a/cdk/__snapshots__/infra.test.ts.snap
+++ b/cdk/__snapshots__/infra.test.ts.snap
@@ -1364,7 +1364,7 @@ systemctl start app
               "Action": "s3:PutObject",
               "Effect": "Allow",
               "Principal": {
-                "AWS": "arn:aws:iam::000000000016:role/galaxies-data-refresher-lambda-role-PROD",
+                "AWS": "arn:aws:iam::000000000035:role/galaxies-data-refresher-lambda-role-PROD",
               },
               "Resource": {
                 "Fn::Join": [
@@ -1392,7 +1392,7 @@ systemctl start app
               },
               "Effect": "Allow",
               "Principal": {
-                "AWS": "arn:aws:iam::000000000016:role/galaxies-data-refresher-lambda-role-PROD",
+                "AWS": "arn:aws:iam::000000000035:role/galaxies-data-refresher-lambda-role-PROD",
               },
               "Resource": {
                 "Fn::GetAtt": [
@@ -1414,11 +1414,11 @@ systemctl start app
                         {
                           "Ref": "AWS::Partition",
                         },
-                        ":iam::000000000016:root",
+                        ":iam::000000000035:root",
                       ],
                     ],
                   },
-                  "arn:aws:iam::000000000016:role/galaxies-data-refresher-lambda-role-CODE",
+                  "arn:aws:iam::000000000035:role/galaxies-data-refresher-lambda-role-CODE",
                 ],
               },
               "Resource": {
@@ -1456,11 +1456,11 @@ systemctl start app
                         {
                           "Ref": "AWS::Partition",
                         },
-                        ":iam::000000000016:root",
+                        ":iam::000000000035:root",
                       ],
                     ],
                   },
-                  "arn:aws:iam::000000000016:role/galaxies-data-refresher-lambda-role-CODE",
+                  "arn:aws:iam::000000000035:role/galaxies-data-refresher-lambda-role-CODE",
                 ],
               },
               "Resource": {

--- a/cdk/infra.ts
+++ b/cdk/infra.ts
@@ -203,16 +203,16 @@ systemctl start ${app}
 				prefix: 'galaxies.gutools.co.uk/data/*',
 				principals: [
 					new ArnPrincipal(
-						`arn:aws:iam::${GuardianAwsAccounts.DeveloperPlayground}:role/galaxies-data-refresher-lambda-role-PROD`,
+						`arn:aws:iam::${GuardianAwsAccounts.HiringAndOnboarding}:role/galaxies-data-refresher-lambda-role-PROD`,
 					),
 				],
 			},
 			CODE: {
 				prefix: 'galaxies.code.dev-gutools.co.uk/data/*',
 				principals: [
-					new AccountPrincipal(GuardianAwsAccounts.DeveloperPlayground), // for local development
+					new AccountPrincipal(GuardianAwsAccounts.HiringAndOnboarding), // for local development
 					new ArnPrincipal(
-						`arn:aws:iam::${GuardianAwsAccounts.DeveloperPlayground}:role/galaxies-data-refresher-lambda-role-CODE`,
+						`arn:aws:iam::${GuardianAwsAccounts.HiringAndOnboarding}:role/galaxies-data-refresher-lambda-role-CODE`,
 					),
 				],
 			},

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@guardian/cdk": "58.0.0",
         "@guardian/eslint-config-typescript": "^10.0.0",
         "@guardian/prettier": "^8.0.0",
-        "@guardian/private-infrastructure-config": "git+ssh://git@github.com/guardian/private-infrastructure-config.git#v2.4.0",
+        "@guardian/private-infrastructure-config": "git+ssh://git@github.com/guardian/private-infrastructure-config.git#c6159b4a0a09d4f3a7a978a6fd48e37b1a2c8e3b",
         "@tsconfig/node20": "^20.1.4",
         "@types/jest": "^29.5.12",
         "@types/js-yaml": "^4.0.9",
@@ -2133,7 +2133,8 @@
     },
     "node_modules/@guardian/private-infrastructure-config": {
       "version": "2.3.0",
-      "resolved": "git+ssh://git@github.com/guardian/private-infrastructure-config.git#5242448b2aabea0e5d7c1729d49113709428f5b3",
+      "resolved": "git+ssh://git@github.com/guardian/private-infrastructure-config.git#c6159b4a0a09d4f3a7a978a6fd48e37b1a2c8e3b",
+      "integrity": "sha512-k9MjOusL49AQN3jqXDkCY5k44LYcphJ92MTCQaFksdWfHesgD6ppEktCqIt2mLBYflUVtFjsM4wHXONSQuLuhA==",
       "dev": true
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -13198,9 +13199,10 @@
       "requires": {}
     },
     "@guardian/private-infrastructure-config": {
-      "version": "git+ssh://git@github.com/guardian/private-infrastructure-config.git#5242448b2aabea0e5d7c1729d49113709428f5b3",
+      "version": "git+ssh://git@github.com/guardian/private-infrastructure-config.git#c6159b4a0a09d4f3a7a978a6fd48e37b1a2c8e3b",
+      "integrity": "sha512-k9MjOusL49AQN3jqXDkCY5k44LYcphJ92MTCQaFksdWfHesgD6ppEktCqIt2mLBYflUVtFjsM4wHXONSQuLuhA==",
       "dev": true,
-      "from": "@guardian/private-infrastructure-config@git+ssh://git@github.com/guardian/private-infrastructure-config.git#v2.4.0"
+      "from": "@guardian/private-infrastructure-config@git+ssh://git@github.com/guardian/private-infrastructure-config.git#c6159b4a0a09d4f3a7a978a6fd48e37b1a2c8e3b"
     },
     "@humanwhocodes/config-array": {
       "version": "0.13.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@guardian/cdk": "58.0.0",
     "@guardian/eslint-config-typescript": "^10.0.0",
     "@guardian/prettier": "^8.0.0",
-    "@guardian/private-infrastructure-config": "git+ssh://git@github.com/guardian/private-infrastructure-config.git#v2.4.0",
+    "@guardian/private-infrastructure-config": "git+ssh://git@github.com/guardian/private-infrastructure-config.git#c6159b4a0a09d4f3a7a978a6fd48e37b1a2c8e3b",
     "@tsconfig/node20": "^20.1.4",
     "@types/jest": "^29.5.12",
     "@types/js-yaml": "^4.0.9",


### PR DESCRIPTION
Co-authored-by: @twrichards

In #14 and #20 we added the ability for galaxies data-refresher-lambda in a different account (playground) to upload data files to the galaxies static site (in the actions static site bucket).

The galaxies data-refresher-lambda is moving to a more stable home in the new 'Hiring & Onboarding' account, this updates those permissions accordingly (which requires https://github.com/guardian/private-infrastructure-config/pull/58, https://github.com/guardian/private-infrastructure-config/pull/59, https://github.com/guardian/private-infrastructure-config/pull/61 and finally https://github.com/guardian/private-infrastructure-config/pull/62)