### PR TITLE
Describe use of actions-riff-raff in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ jobs:
           guActionsRiffRaffRoleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
 ```
 
+Each run of actions-static-site uses actions-riff-raff to create a new build in
+a Riff Raff project which deploys your static site. This allows you to configure
+deployment as usual using Riff Raff, for example by setting up continuous
+deployment to deploy any new builds on the main branch. It also means your
+repository needs to have the necessary access to write to that Riff Raff project
+(`deploy::<app>`).
+
+
 ## Inputs
 
 ### **app** `string` (required):

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ jobs:
       contents: read
 
     steps:
-      # ... (Buiild your static site.)
+      # ... (Build your static site.)
 
       # Then upload it as an artifact
       - uses: actions/upload-artifact@v3


### PR DESCRIPTION
## What does this change?

When deploying a static site recently for [datawrapper-import](https://github.com/guardian/datawrapper-import), it wasn’t clear to me that the repository needed to have the necessary access for Riff Raff to successfully write files for the `deploy::datawrapper-import` project. Hopefully this message makes it clearer that that access needs to be set up when setting up a new static site.