### PR TITLE
Update download-artifact to v4 following deprecation of v3

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -48,7 +48,7 @@ jobs:
           </html>
           EOF
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: my-site
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# @guardian/actions-static-site V2
+# @guardian/actions-static-site V3
 
 Action to provision and serve a static site with Google Auth and a custom
 domain.
@@ -33,12 +33,12 @@ jobs:
       # ... (Build your static site.)
 
       # Then upload it as an artifact
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: my-site
 
       # Then invoke this action (replacing app and domain)
-      - uses: guardian/actions-static-site@v2
+      - uses: guardian/actions-static-site@v3
         with:
           app: example
           domain: example.gutools.co.uk

--- a/action.yaml
+++ b/action.yaml
@@ -35,7 +35,7 @@ runs:
         INPUT_DRYRUN: ${{ inputs.dryRun}}
         INPUT_ACTIONS_RUNTIME_TOKEN: ${ github.token }
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.artifact }}
         path: site


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Github has sent us a notice that v3 of this action will be deprecated by December 5, 2024., so we need to switch to v4.

Fixes https://github.com/guardian/actions-static-site/issues/38