### PR TITLE
Try main module ESM fix

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,37 +1,43 @@
-import * as fs from "fs";
-import * as core from "@actions/core";
-import { App } from "aws-cdk-lib";
-import { Template } from "aws-cdk-lib/assertions";
-import { StaticSite } from "./cdk/static-site";
+import * as fs from 'fs';
+import * as url from 'node:url';
+import * as core from '@actions/core';
+import { App } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { StaticSite } from './cdk/static-site';
 
 export const main = (): void => {
-  const app = core.getInput("app", { required: true });
-  const domain = core.getInput("domain", { required: true });
+	const app = core.getInput('app', { required: true });
+	const domain = core.getInput('domain', { required: true });
 
-  const stack = "deploy";
+	const stack = 'deploy';
 
-  core.info(
-    "Inputs are: " +
-      JSON.stringify({ app, stack, domain })
-  );
+	core.info('Inputs are: ' + JSON.stringify({ app, stack, domain }));
 
-  const cdkApp = new App();
-  const cdkStack = new StaticSite(cdkApp, "static-site", {
-    app,
-    stack,
-    stage: "PROD",
-    domainName: domain,
-  });
+	const cdkApp = new App();
+	const cdkStack = new StaticSite(cdkApp, 'static-site', {
+		app,
+		stack,
+		stage: 'PROD',
+		domainName: domain,
+	});
 
-  const cfn = Template.fromStack(cdkStack).toJSON();
-  fs.writeFileSync("cfn.json", JSON.stringify(cfn, undefined, 2));
+	const cfn = Template.fromStack(cdkStack).toJSON();
+	fs.writeFileSync('cfn.json', JSON.stringify(cfn, undefined, 2));
 };
 
 try {
-  // execute only if invoked as main script (rather than test)
-  if (require.main === module) {main()}
+	// execute only if invoked as main script (rather than test)
+	if (import.meta.url.startsWith('file:')) {
+		// (A)
+		const modulePath = url.fileURLToPath(import.meta.url);
+		if (process.argv[1] === modulePath) {
+			// (B)
+			// Main ESM module
+			main();
+		}
+	}
 } catch (e) {
-  const error = e as Error;
-  core.error(error);
-  core.setFailed(error.message);
+	const error = e as Error;
+	core.error(error);
+	core.setFailed(error.message);
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,8 @@
 {
-  "extends": "@tsconfig/node20/tsconfig.json"
+	"extends": "@tsconfig/node20/tsconfig.json",
+	"compilerOptions": {
+		"module": "esnext",
+		"target": "esnext",
+		"moduleResolution": "bundler"
+	}
 }


### PR DESCRIPTION
Trying out a fix based on the suggestion from @Jakeii here: https://github.com/guardian/actions-static-site/pull/23#discussion_r1919804623

The fix itself is taken from https://exploringjs.com/nodejs-shell-scripting/ch_nodejs-path.html#determining-if-an-esm-module-is-main

This allows the [`test` CI action to pass](https://github.com/guardian/actions-static-site/actions/runs/12833885003).

**nb.** I also had to change the compiler options in tsconfig to get `tsc` to work without complaining about relative module imports, although I think this was a pre-existing issue? I don't have a wonderful understanding of module resolution in `tsconfig`, but I was comforted by the fact that the built `index.js` [doesn't seem to have changed](https://github.com/guardian/actions-static-site/pull/39/commits/8b4a41187dfb2872f370a4c7665cf0f2fb4939a0) as a result of the compiler options change.