### PR TITLE
Change the `commentingStage` value to PROD

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -82,3 +82,4 @@ runs:
                 prefixStage: false
               dependencies:
                 - cfn
+        commentingStage: PROD


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This PR changes commentingStage value to PROD for `actions-riff-raff@v4` in the `action.yaml`.

When anyone upgrades `guardian/actions-static-site` from v2 to v3 that also upgrades automatically to `guardian/actions-riff-raff@v4` which by default has [commentingStage](https://github.com/guardian/actions-riff-raff?tab=readme-ov-file#commentingstage) as an input with a default value CODE but static-site doesn't have a CODE environment that's why we need to change this input to be PROD.

As you can see from the screenshot below it failed after 0s with CODE. 

<img width="1154" alt="image" src="https://github.com/user-attachments/assets/94324187-7998-455a-9896-73f8d1bf2e41" />

The Github actions comment that got the riff-raff Deploy build number automatically has CODE as environment which you can currently see in this PR https://github.com/guardian/deacronym/pull/15

<img width="851" alt="image" src="https://github.com/user-attachments/assets/8987ea71-1598-4c94-b932-1a66d1982af9" />
