### PR TITLE
Improve `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ your files in S3 and data transfer costs - as the core infrastructure is shared.
 **Note: your domain must be registered with the Google project for the Google
 auth callback to work - ping it on the `DevX Stream` channel and we can quickly add this for you.**
 
-**You will also need to add your repo to [riffraff-platform](https://github.com/guardian/riffraff-platform?tab=readme-ov-file#adding-a-new-repository), with riffraff project name `deploy::*appname*`**
+**You will also need to add your repo to [riffraff-platform](https://github.com/guardian/riffraff-platform?tab=readme-ov-file#adding-a-new-repository), with riffraff project name `deploy::*appname*`** - for example [guardian/deacronym#399](https://github.com/guardian/riffraff-platform/pull/399).
+
+You will need to merge the **riffraff-platform** PR before you start creating your `@guardian/actions-static-site` job otherwise the build will fail as your repository expects to have `GU_RIFF_RAFF_ROLE_ARN` in your respository secrets and that gets generated after the merge.
+
+Also it would be good to know that `@guardian/actions-static-site` has just **PROD** environment. For more details check [#41](https://github.com/guardian/actions-static-site/pull/41).
 
 Any paths ending in `/_prout` will skip authentication, so feel free to add the git hash as a file called `_prout` and then wire it up to [PRout](https://github.com/guardian/prout) - for example [guardian/galaxies#102](https://github.com/guardian/galaxies/pull/102).
 
@@ -30,6 +34,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      pull-requests: write
 
     steps:
       # ... (Build your static site.)


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This PR improves the README with the necessary steps that anyone would need to use for setting up a static site with `@guardian/actions-static-site` job.  

I took me longer than it should take to setup a static-site for `guardian/deacronym` because I was just following what's in the README so from now on I just want to make the process easier for anyone else. 
