### PR TITLE
Fix the example url with the correct repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ your files in S3 and data transfer costs - as the core infrastructure is shared.
 **Note: your domain must be registered with the Google project for the Google
 auth callback to work - ping it on the `DevX Stream` channel and we can quickly add this for you.**
 
-**You will also need to add your repo to [riffraff-platform](https://github.com/guardian/riffraff-platform?tab=readme-ov-file#adding-a-new-repository), with riffraff project name `deploy::*appname*`** - for example [guardian/deacronym#399](https://github.com/guardian/riffraff-platform/pull/399).
+**You will also need to add your repo to [riffraff-platform](https://github.com/guardian/riffraff-platform?tab=readme-ov-file#adding-a-new-repository), with riffraff project name `deploy::*appname*`** - for example [guardian/riffraff-platform#399](https://github.com/guardian/riffraff-platform/pull/399).
 
 You will need to merge the **riffraff-platform** PR before you start creating your `@guardian/actions-static-site` job otherwise the build will fail as your repository expects to have `GU_RIFF_RAFF_ROLE_ARN` in your respository secrets and that gets generated after the merge.
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This PR is a follow up of https://github.com/guardian/actions-static-site/pull/42 to update the example repo name to the correct one.