### PR TITLE
Added section how to decommission no longer needed site to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ an earlier workflow step.
 
 1. **Remove the stack**
    You need access to the deployTools account to do this. Either get the permissions from janus, or ask DevX.
-   Delete the `deploy-PROD-<app>` stack.
+   Delete the `deploy-PROD-<app>` stack. This will remove the resources defined in [static-site.ts](./cdk/static-site.ts)
    _Optional:_ You may also delete the relevant content from the S3 bucket, but this is usually unnecessary due to the small file sizes.
 
 2. **Remove the authorised redirect URI in Google Cloud Console**


### PR DESCRIPTION
This pull request updates the `README.md` file to include additional instructions for managing static sites in Google Cloud Console and decommissioning unused static sites. These changes aim to improve clarity and provide step-by-step guidance for developers.

### Updates to Google Cloud Console instructions:

* Added detailed steps for adding a new authorized redirect URI in Google Cloud Console under the `devx-gh-actions-static-site` project.

### Decommissioning static sites:

* Added a new section on how to decommission a static site, including steps to remove the stack, delete the authorized redirect URI in Google Cloud Console, and archive the repository in GitHub.