### PR TITLE
Update Dependabot schedule interval to quarterly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'monthly'
+      interval: 'quarterly'
     ignore:
       # The version of AWS CDK libraries must match those from @guardian/cdk.
       # We'd never be able to update them here independently, so just ignore them.
@@ -13,4 +13,4 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'monthly'
+      interval: 'quarterly'


### PR DESCRIPTION
## What does this change?

Updates the Dependabot schedule interval from the current value to `quarterly`, so dependency update PRs are raised on the first day of each quarter (January, April, July, October).

