### PR TITLE
Configure Dependabot to update AWS SDKs for Go in unison

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,19 @@ updates:
       - dependency-name: 'aws-cdk'
       - dependency-name: 'aws-cdk-lib'
       - dependency-name: 'constructs'
+  - package-ecosystem: gomod
+    directory: 'service'
+    schedule:
+      interval: quarterly
+    commit-message:
+      prefix: "chore(deps): "
+    groups:
+      # The AWS SDK dependencies must be updated in unison.
+      # See https://github.com/aws/aws-sdk-go-v2/issues/2370#issuecomment-1878423518.
+      aws-sdk:
+        patterns:
+          - "github.com/aws/aws-sdk-go-v2"
+          - "github.com/aws/aws-sdk-go-v2/*"
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:


### PR DESCRIPTION
## What does this change?
https://github.com/guardian/actions-static-site/pull/101 was reverted in https://github.com/guardian/actions-static-site/pull/104 as it was yielding 404 responses.

This change updates Dependabot to update the AWS SDK dependencies in unison.

See also https://github.com/aws/aws-sdk-go-v2/issues/2370#issuecomment-1814960128.
