### PR TITLE
Support multiple static sites from a single CI pipeline

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -38,6 +38,10 @@ runs:
         INPUT_DRYRUN: ${{ inputs.dryRun}}
         INPUT_ACTIONS_RUNTIME_TOKEN: ${ github.token }
 
+    - name: Clear site folder in preparation for artifact download
+      shell: bash
+      run: rm -rf site
+
     - uses: actions/download-artifact@v8
       with:
         name: ${{ inputs.artifact }}


### PR DESCRIPTION
## What does this change?

Clear site folder in preparation for artifact download

Currently CI pipelines that deploy multiple static sites include the assets from the first site in the second site because the contents of the site folder is not cleared between calls to actions-static-site