### PR TITLE
chore: Update AMIgo image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
                   amiParameter: AMIActionsstaticsiteinfra
                   amiTags:
                     BuiltBy: amigo
-                    Recipe: arm64-focal-java11-deploy-infrastructure
+                    Recipe: arm64-jammy-java21-deploy-infrastructure
                     AmigoStage: PROD
               app:
                 app: actions-static-site-infra


### PR DESCRIPTION
## What does this change?
I think think this service actually needs Java, however before delving into that, this change updates the AMI to one with Java 21.

See also https://github.com/guardian/actions-static-site/pull/17.

## How has this change been tested?
This is a singleton stack, so we can only test by merging.