### PR TITLE
fix: Correct routing for alarms

### DIFF
--- a/cdk/__snapshots__/infra.test.ts.snap
+++ b/cdk/__snapshots__/infra.test.ts.snap
@@ -6,7 +6,6 @@ exports[`static site INFRA should match snapshot 1`] = `
     "gu:cdk:constructs": [
       "GuS3Bucket",
       "GuDistributionBucketParameter",
-      "GuAnghammaradTopicParameter",
       "GuVpcParameter",
       "GuSubnetListParameter",
       "GuSubnetListParameter",
@@ -51,11 +50,6 @@ exports[`static site INFRA should match snapshot 1`] = `
     "AccessLoggingBucket": {
       "Default": "/account/services/access-logging/bucket",
       "Description": "S3 bucket to store your access logs",
-      "Type": "AWS::SSM::Parameter::Value<String>",
-    },
-    "AnghammaradSnsArn": {
-      "Default": "/account/services/anghammarad.topic.arn",
-      "Description": "SSM parameter containing the ARN of the Anghammarad SNS topic",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
     "DistributionBucketName": {
@@ -403,10 +397,7 @@ exports[`static site INFRA should match snapshot 1`] = `
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":",
-                {
-                  "Ref": "AnghammaradSnsArn",
-                },
+                ":devx-reliabilityandoperations",
               ],
             ],
           },
@@ -969,10 +960,7 @@ exports[`static site INFRA should match snapshot 1`] = `
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":",
-                {
-                  "Ref": "AnghammaradSnsArn",
-                },
+                ":devx-reliabilityandoperations",
               ],
             ],
           },

--- a/cdk/infra.ts
+++ b/cdk/infra.ts
@@ -3,7 +3,6 @@ import { GuEc2App } from '@guardian/cdk';
 import { AccessScope } from '@guardian/cdk/lib/constants';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import {
-	GuAnghammaradTopicParameter,
 	GuDistributionBucketParameter,
 	GuStack,
 } from '@guardian/cdk/lib/constructs/core';
@@ -100,8 +99,7 @@ EOF`,
 			instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.NANO),
 			applicationPort: port,
 			monitoringConfiguration: {
-				snsTopicName:
-					GuAnghammaradTopicParameter.getInstance(this).valueAsString,
+				snsTopicName: 'devx-reliabilityandoperations', // DevX RelOps owns this service, so route alarms to them
 				unhealthyInstancesAlarm: true,
 				http5xxAlarm: {
 					tolerated5xxPercentage: 1,


### PR DESCRIPTION
## What does this change?
The `monitoringConfiguration` of a `GuEc2App` requires an SNS topic _name_. We were providing the _ARN_ of the Anghammarad topic.

This change updates the configuration to use the `devx-reliabilityandoperations` topic. Anghammarad doesn't know how to parse an alarm, so routing the alarm there is not correct.